### PR TITLE
Simplify compose widget and put text at a higher position in conversation messages

### DIFF
--- a/client/app/components/mails_input.coffee
+++ b/client/app/components/mails_input.coffee
@@ -104,10 +104,6 @@ module.exports = MailsInput = React.createClass
                     placeholder: @props.placeholder
                     'autoComplete': 'off'
                     'spellCheck': 'off'
-                div
-                    className: 'btn btn-cozy btn-contact',
-                    onClick: @onQuery,
-                        span className: 'fa fa-search'
 
                 if @state.contacts?
                     ul className: "dropdown-menu contact-list",

--- a/client/app/styles/_compose.styl
+++ b/client/app/styles/_compose.styl
@@ -4,6 +4,7 @@
 #email-compose
     width 100%
     max-width 800px
+    margin-bottom 20px
 
     &.enable
         display block
@@ -11,8 +12,8 @@
     h3
         color #444
         margin-top 0
-        padding-top 1em
-        margin-bottom 2em
+        padding-top 0.5em
+        margin-bottom 1em
 
     a.close-email
         margin-right 0
@@ -87,8 +88,7 @@
       height 2em
       padding 0.2em 0.5em
       overflow hidden
-      width calc(100% - 4em)
-      max-width 750px
+      width 100%
       display inline
       resize none
 

--- a/client/app/styles/_conversation.styl
+++ b/client/app/styles/_conversation.styl
@@ -43,7 +43,7 @@
             background-color orange
 
     .message-title
-        margin-top 0.5em
+        margin-bottom 0.5em
         line-height 1.4em
         border 0
 
@@ -75,13 +75,13 @@
             .messageNavigation
 
                 .btn-toolbar
-                  margin-right .5em
-                  padding-top 1em
-                  margin-bottom 2em
-                  border-top 1px solid #CCC
+                    margin-right .5em
+                    padding-top 1em
+                    margin-bottom 1em
+                    border-top 1px solid #CCC
 
             .messageToolbox
-                margin-top 2em
+                margin-top 1em
 
                 .btn.btn-default
                     background none


### PR DESCRIPTION
Hi,

Here is a proposal for improving email ux a little bit for compose and email reading:

* Remove the magnifying glass
* Improve margin styles of the compose widget
* Reduce margins in conversation messages