### PR TITLE
Display all info and error alerts through toasters

### DIFF
--- a/client/app/actions/layout_action_creator.coffee
+++ b/client/app/actions/layout_action_creator.coffee
@@ -40,40 +40,44 @@ module.exports = LayoutActionCreator =
                     type: _cachedDisposition.type
                     value: 0
 
-    alert: (level, message) ->
-        AppDispatcher.handleViewAction
-            type: ActionTypes.DISPLAY_ALERT
-            value:
-                level: level
-                message: message
-
-    alertHide: (level, message) ->
-        AppDispatcher.handleViewAction
-            type: ActionTypes.HIDE_ALERT
-
     refresh: ->
         AppDispatcher.handleViewAction
             type: ActionTypes.REFRESH
             value: null
 
+    alert: (message) ->
+        LayoutActionCreator.notify message,
+            level: AlertLevel.INFO
+            autoclose: true
+
     alertSuccess: (message) ->
-        LayoutActionCreator.alert AlertLevel.SUCCESS, message
-    alertInfo:    (message) ->
-        LayoutActionCreator.alert AlertLevel.INFO, message
+        LayoutActionCreator.notify message,
+            level: AlertLevel.SUCCESS
+            autoclose: true
+
     alertWarning: (message) ->
-        LayoutActionCreator.alert AlertLevel.WARNING, message
-    alertError:   (message) ->
-        LayoutActionCreator.alert AlertLevel.ERROR, message
+        LayoutActionCreator.notify message,
+            level: AlertLevel.WARNING
+            autoclose: true
+
+    alertError: (message) ->
+        LayoutActionCreator.notify message,
+            level: AlertLevel.ERROR
+            autoclose: true
+
     notify: (message, options) ->
         task =
             id: Date.now()
             finished: true
             message: message
+
         if options?
             task.autoclose = options.autoclose
-            task.errors    = options.errors
-            task.finished  = options.finished
-            task.actions   = options.actions
+            task.errors = options.errors
+            task.finished = options.finished
+            task.actions = options.actions
+            task.level = options.level
+
         AppDispatcher.handleViewAction
             type: ActionTypes.RECEIVE_TASK_UPDATE
             value: task
@@ -220,7 +224,6 @@ module.exports = LayoutActionCreator =
                 SearchActionCreator.receiveRawSearchResults results
 
     showSettings: (panelInfo, direction) ->
-
 
     refreshMessages: ->
         XHRUtils.refresh true, (err, results) ->

--- a/client/app/components/account-config.coffee
+++ b/client/app/components/account-config.coffee
@@ -545,14 +545,17 @@ AccountConfigMain = React.createClass
     toggleSMTPAdvanced: ->
         @setState smtpAdvanced: not @state.smtpAdvanced
 
+    # Ask to main layout manager to display error as notification toasters.
     renderError: ->
         if @props.error and @props.error.name is 'AccountConfigError'
             message = t 'config error ' + @props.error.field
-            div className: 'alert alert-warning', message
+            LAC.alertError message
+
         else if @props.error
-            div className: 'alert alert-warning', @props.error.message
+            LAC.alertError @props.error.message
+
         else if Object.keys(@state.errors).length isnt 0
-            div className: 'alert alert-warning', t 'account errors'
+            LAC.alertError t 'account errors'
 
     discover: (event) ->
         @props.validateForm event

--- a/client/app/components/application.coffee
+++ b/client/app/components/application.coffee
@@ -3,7 +3,7 @@
 AccountConfig = require './account-config'
 Alert         = require './alert'
 Topbar        = require './topbar'
-ToastContainer = require('./toast').Container
+ToastContainer = require './toast_container'
 Compose       = require './compose'
 Conversation  = require './conversation'
 Menu          = require './menu'

--- a/client/app/components/mails_input.coffee
+++ b/client/app/components/mails_input.coffee
@@ -4,6 +4,7 @@ MessageUtils    = require '../utils/message_utils'
 Modal           = require './modal'
 ContactStore    = require '../stores/contact_store'
 ContactActionCreator = require '../actions/contact_action_creator'
+LayoutActionCreator = require '../actions/layout_action_creator'
 
 classer = React.addons.classSet
 
@@ -259,13 +260,11 @@ module.exports = MailsInput = React.createClass
                     # twiced due to multiple blur and key down.
                     # Do not display anything when the field is blurred.
                     isContacts = @state.contacts?.length is 0
-                    if not @isShowingAlert and not isBlur and isContacts
-                        @isShowingAlert = true
-                        alert t('compose wrong email format',
-                            address: address.address)
-                        setTimeout =>
-                            @isShowingAlert = false
-                        , 200
+                    if not isBlur and isContacts
+
+                        msg = t 'compose wrong email format',
+                            address: address.address
+                        LayoutActionCreator.alertError msg
 
             else
                 @setState state

--- a/client/app/components/message-list.coffee
+++ b/client/app/components/message-list.coffee
@@ -842,7 +842,3 @@ MessagesSort = React.createClass
         params.accountID = @props.accountID
         params.mailboxID = @props.mailboxID
         LayoutActionCreator.showMessageList parameters: params
-        #@redirect @buildUrl
-        #    direction: 'first'
-        #    action: 'account.mailbox.messages.full'
-        #    parameters: params

--- a/client/app/components/toast.coffee
+++ b/client/app/components/toast.coffee
@@ -5,69 +5,46 @@ Modal           = require './modal'
 StoreWatchMixin = require '../mixins/store_watch_mixin'
 LayoutStore      = require '../stores/layout_store'
 LayoutActionCreator = require '../actions/layout_action_creator'
-{ActionTypes} = require '../constants/app_constants'
+{ActionTypes, AlertLevel} = require '../constants/app_constants'
 {CSSTransitionGroup} = React.addons
 
 classer = React.addons.classSet
 
+
+# The toast is a notification widget displayed on the top right of the screen.
+# It stays temporarly and is dismissed just after a few seconds.
+# This Component can be used to display informative modals.
 module.exports = Toast = React.createClass
+
     displayName: 'Toast'
+
 
     getInitialState: ->
         return modalErrors: false
 
-    closeModal: ->
-        @setState modalErrors: false
 
-    showModal: (errors) ->
-        @setState modalErrors: errors
-
-    acknowledge: ->
-        AppDispatcher.handleViewAction
-            type: ActionTypes.RECEIVE_TASK_DELETE
-            value: @props.toast.get('id')
-
-    renderModal: ->
-        title       = t 'modal please contribute'
-        subtitle    = t 'modal please report'
-        modalErrors = @state.modalErrors
-        closeModal  = @closeModal
-        closeLabel  = t 'app alert close'
-        content = React.DOM.pre
-            style: "max-height": "300px",
-            "word-wrap": "normal",
-                @state.modalErrors.join "\n\n"
-        Modal {title, subtitle, content, closeModal, closeLabel}
-
+    # A toast is composed of several elements:
+    # * message, the displayed text.
+    # * close button, to dismiss the toast before the timeout ends.
+    # * action button, to enable actions like undoing
+    #
+    # If there are errors attached to the toast, a modal is displayed instead
+    # of a toast. The modal give stacktrace so the user can communicate it
+    # to the Cozy team.
     render: ->
         toast = @props.toast.toJS()
         hasErrors = toast.errors? and toast.errors.length
         classes = classer
             toast: true
             'alert-dismissible': toast.finished
-            'alert-info': not hasErrors
-            'alert-warning': hasErrors
-        if toast.done? and toast.total?
-            percent = parseInt(100 * toast.done / toast.total) + '%'
+            'toast-error': toast.level is AlertLevel.ERROR
+
         if hasErrors
-            showModal = @showModal.bind(this, toast.errors)
+            showModal = @showModal.bind this, toast.errors
 
         div className: classes, role: "alert", key: @props.key,
             if @state.modalErrors
                 @renderModal()
-
-            if percent?
-                div className: "progress",
-                    div
-                        className: 'progress-bar',
-                        style: width: percent
-                    div
-                        className: 'progress-bar-label start',
-                        style: width: percent,
-                        "#{t "task " + toast.code, toast} : #{percent}"
-                    div
-                        className: 'progress-bar-label end',
-                        "#{t "task " + toast.code, toast} : #{percent}"
 
             if toast.message
                 div className: "message", toast.message
@@ -81,10 +58,11 @@ module.exports = Toast = React.createClass
                         span className: "sr-only", t "app alert close"
 
             if toast.actions?
+                className = "btn btn-cancel btn-cozy-non-default btn-xs"
                 div className: 'toast-actions',
                     toast.actions.map (action, id) ->
                         button
-                            className: "btn btn-cancel btn-cozy-non-default btn-xs",
+                            className: className,
                             type: "button",
                             key: id
                             onClick: action.onClick,
@@ -96,69 +74,29 @@ module.exports = Toast = React.createClass
                         t 'there were errors', smart_count: toast.errors.length
 
 
-module.exports.Container = ToastContainer =  React.createClass
-    displayName: 'ToastContainer'
+    renderModal: ->
+        title       = t 'modal please contribute'
+        subtitle    = t 'modal please report'
+        modalErrors = @state.modalErrors
+        closeModal  = @closeModal
+        closeLabel  = t 'app alert close'
+        content = React.DOM.pre
+            style: "max-height": "300px",
+            "word-wrap": "normal",
+                @state.modalErrors.join "\n\n"
+        Modal {title, subtitle, content, closeModal, closeLabel}
 
-    mixins: [
-        StoreWatchMixin [LayoutStore]
-    ]
 
-    getStateFromStores: ->
-        return {
-            toasts: LayoutStore.getToasts()
-            hidden: not LayoutStore.isShown()
-        }
+    closeModal: ->
+        @setState modalErrors: false
 
-    shouldComponentUpdate: (nextProps, nextState) ->
-        return not(_.isEqual(nextState, @state)) or not (_.isEqual(nextProps, @props))
 
-    render: ->
-        toasts = @state.toasts.map (toast, id) ->
-            Toast {toast, key: id}
-        .toVector().toJS()
+    showModal: (errors) ->
+        @setState modalErrors: errors
 
-        classes = classer
-            'toasts-container': true
-            'action-hidden': @state.hidden
-            'has-toasts': toasts.length isnt 0
 
-        div className: classes,
-            CSSTransitionGroup transitionName: "toast",
-                toasts
-            div className: 'alert alert-success toast toasts-actions',
-                span
-                    className: "toast-action hide-action",
-                    title: t 'toast hide'
-                    onClick: @toggleHidden,
-                        i className: 'fa fa-eye-slash'
-                span
-                    className: "toast-action show-action",
-                    title: t 'toast show'
-                    onClick: @toggleHidden,
-                        i className: 'fa fa-eye'
-                span
-                    className: "toast-action close-action",
-                    title: t 'toast close all'
-                    onClick: @closeAll,
-                        i className: 'fa fa-times'
+    acknowledge: ->
+        AppDispatcher.handleViewAction
+            type: ActionTypes.RECEIVE_TASK_DELETE
+            value: @props.toast.get 'id'
 
-    toggleHidden: ->
-        if @state.hidden
-            LayoutActionCreator.toastsShow()
-        else
-            LayoutActionCreator.toastsHide()
-
-    closeAll: ->
-        LayoutActionCreator.clearToasts()
-
-    _clearToasts: ->
-        setTimeout ->
-            Array.prototype.forEach.call document.querySelectorAll('.toast-enter'), (e) ->
-                e.classList.add 'hidden'
-        , 10000
-
-    componentDidMount: ->
-        @_clearToasts()
-
-    componentDidUpdate: ->
-        @_clearToasts()

--- a/client/app/components/toast_container.coffee
+++ b/client/app/components/toast_container.coffee
@@ -1,0 +1,74 @@
+{div} = React.DOM
+Modal           = require './modal'
+Toast           = require './toast'
+StoreWatchMixin = require '../mixins/store_watch_mixin'
+LayoutStore      = require '../stores/layout_store'
+LayoutActionCreator = require '../actions/layout_action_creator'
+{CSSTransitionGroup} = React.addons
+
+classer = React.addons.classSet
+
+
+# Main container in wich toasts are displayed.
+module.exports = ToastContainer =  React.createClass
+    displayName: 'ToastContainer'
+
+    mixins: [
+        StoreWatchMixin [LayoutStore]
+    ]
+
+
+    getStateFromStores: ->
+        return {
+            toasts: LayoutStore.getToasts()
+            hidden: not LayoutStore.isShown()
+        }
+
+
+    shouldComponentUpdate: (nextProps, nextState) ->
+        isNextState = _.isEqual nextState, @state
+        isNextProps = _.isEqual nextProps, @props
+        return not(isNextState and isNextProps)
+
+
+    render: ->
+        toasts = @state.toasts.map (toast, id) ->
+            Toast {toast, key: id}
+        .toVector().toJS()
+
+        classes = classer
+            'toasts-container': true
+            'action-hidden': @state.hidden
+            'has-toasts': toasts.length isnt 0
+
+        div className: classes,
+            CSSTransitionGroup transitionName: "toast",
+                toasts
+
+
+    toggleHidden: ->
+        if @state.hidden
+            LayoutActionCreator.toastsShow()
+        else
+            LayoutActionCreator.toastsHide()
+
+    # Clear hidden toasts on a regular basis.
+    _clearToasts: ->
+        setTimeout ->
+            toasts = document.querySelectorAll('.toast-enter')
+            Array.prototype.forEach.call toasts, (e) ->
+                e.classList.add 'hidden'
+        , 10000
+
+
+    closeAll: ->
+        LayoutActionCreator.clearToasts()
+
+
+    componentDidMount: ->
+        @_clearToasts()
+
+
+    componentDidUpdate: ->
+        @_clearToasts()
+

--- a/client/app/locales/en.coffee
+++ b/client/app/locales/en.coffee
@@ -313,7 +313,7 @@ module.exports =
       "modal please contribute"    : "Please contribute"
 
       # Validation
-      "validate must not be empty" : "Mandatory field"
+      "validate must not be empty" : "This field is required"
 
       # Toast
       "toast hide"      : "Hide alerts"

--- a/client/app/stores/layout_store.coffee
+++ b/client/app/stores/layout_store.coffee
@@ -72,10 +72,11 @@ class LayoutStore extends Store
             @emit 'change'
 
         handle ActionTypes.RECEIVE_TASK_UPDATE, (task) =>
+            console.log task
             task = Immutable.Map task
-            id = task.get('id')
+            id = task.get 'id'
             _tasks = _tasks.set id, task
-            if task.get('autoclose')
+            if task.get 'autoclose'
                 remove = =>
                     _tasks = _tasks.remove id
                     @emit 'change'

--- a/client/app/styles/_conversation.styl
+++ b/client/app/styles/_conversation.styl
@@ -225,8 +225,8 @@
             color grey
             border 0
 
-            i
-                padding-right .75em
+        i
+            padding-right .75em
 
         .btn-success
         .btn-info

--- a/client/app/styles/_toasts.styl
+++ b/client/app/styles/_toasts.styl
@@ -16,7 +16,6 @@
         pointer-events auto
         opacity 1
 
-
     .toast
         position relative
         top 20px
@@ -49,6 +48,9 @@
 
         &.toast-leave-active
             left 500px
+
+        &.toast-error
+            background #D9848C
 
         button.btn.btn-cancel.btn-cozy-non-default
             border 0


### PR DESCRIPTION
To unify alert messages, this PR make Emails always displaying a toaster when something happens. It simplifies code and UI behavior. 
By the way I splitted the toaster file in two: one for each components.