### PR TITLE
[HOTFIX] Incompatibility with couchdb 1.3

### DIFF
--- a/build/server/models/requests.js
+++ b/build/server/models/requests.js
@@ -67,13 +67,12 @@ module.exports = {
     byMailboxRequest: {
       reduce: '_count',
       map: function(doc) {
-        var boxid, docDate, i, len, ref, ref1, ref2, uid, xflag;
-        if (Object.keys(doc.mailboxIDs).length === 0) {
-          emit(['nobox']);
-        }
+        var boxid, docDate, i, len, nobox, ref, ref1, ref2, uid, xflag;
+        nobox = true;
         ref = doc.mailboxIDs;
         for (boxid in ref) {
           uid = ref[boxid];
+          nobox = false;
           docDate = doc.date || (new Date()).toISOString();
           emit(['uid', boxid, uid], doc.flags);
           emit(['date', boxid, null, docDate], null);
@@ -92,7 +91,10 @@ module.exports = {
             emit(['subject', boxid, '\\Attachments', doc.normSubject], null);
           }
         }
-        return void 0;
+        void 0;
+        if (nobox) {
+          return emit(['nobox']);
+        }
       }
     },
     dedupRequest: function(doc) {

--- a/server/models/requests.coffee
+++ b/server/models/requests.coffee
@@ -39,10 +39,10 @@ module.exports =
         byMailboxRequest:
             reduce: '_count'
             map: (doc) ->
-                if Object.keys(doc.mailboxIDs).length is 0
-                    emit ['nobox']
+                nobox = true
 
                 for boxid, uid of doc.mailboxIDs
+                    nobox = false
                     docDate = doc.date or (new Date()).toISOString()
                     emit ['uid', boxid, uid], doc.flags
 
@@ -60,6 +60,9 @@ module.exports =
                         emit ['subject', boxid, '\\Attachments', \
                                                         doc.normSubject], null
                 undefined # prevent coffeescript comprehension
+
+                if nobox
+                    emit ['nobox']
 
         # this map is used to dedup by message-id
         dedupRequest: (doc) ->


### PR DESCRIPTION
The new bymailboxrequest used Object.keys which is not available in couchdb 1.3 javascript environment.

I am making the PR as an "hotfix" against master, because this bug will cause all mails to be reimported twice for user using couchdb 1.3 ...