### PR TITLE
Added: last refresh date as tooltip on refresh button. Refs #125.

### DIFF
--- a/client/app/components/menu.coffee
+++ b/client/app/components/menu.coffee
@@ -106,10 +106,13 @@ module.exports = Menu = React.createClass
                         @getAccountRender account, key
                     .toJS()
 
-            RefreshIndicator
-                refreshes: @props.refreshes
-                mailboxes: @props.selectedAccount.get('mailboxes')
-                selectedMailboxID: @props.selectedMailboxID
+            # This component doesn't make sense if there is no account. There is
+            # always a selected account if there is an account.
+            if @props.selectedAccount?
+                RefreshIndicator
+                    refreshes: @props.refreshes
+                    mailboxes: @props.selectedAccount.get('mailboxes')
+                    selectedMailboxID: @props.selectedMailboxID
 
             a
                 href: newMailboxUrl,

--- a/client/app/components/menu.coffee
+++ b/client/app/components/menu.coffee
@@ -106,8 +106,10 @@ module.exports = Menu = React.createClass
                         @getAccountRender account, key
                     .toJS()
 
-
-            RefreshIndicator refreshes: @props.refreshes
+            RefreshIndicator
+                refreshes: @props.refreshes
+                mailboxes: @props.selectedAccount.get('mailboxes')
+                selectedMailboxID: @props.selectedMailboxID
 
             a
                 href: newMailboxUrl,

--- a/client/app/components/menu_refresh_indicator.coffee
+++ b/client/app/components/menu_refresh_indicator.coffee
@@ -11,6 +11,8 @@ module.exports = React.createClass
 
     protoTypes:
         refreshes: React.PropTypes.object.isRequired
+        selectedAccount: React.PropTypes.object.isRequired
+        selectedMailboxID: React.PropTypes.string
 
     # Define a flag to know if the user has clicked in order to show the spinner
     # immediately, otherwise there is a small time before it starts due to some
@@ -27,12 +29,14 @@ module.exports = React.createClass
             # and the user has not triggered it.
             if @props.refreshes.length is 0 and not @state.isRefreshStarted
                 button
-                    className: '',
-                    type: 'button',
-                    disabled: null,
+                    className: ''
+                    type: 'button'
+                    disabled: null
+                    title: t("menu last refresh", date: @getFormattedDate())
                     onClick: @refresh,
                         span className: 'fa fa-refresh'
                         span null, t("menu refresh label")
+
 
             # Or an indicator of the progress if a refresh is occurring.
             else
@@ -79,6 +83,21 @@ module.exports = React.createClass
         mailbox = mailboxes.first()
 
         return {account, mailbox}
+
+
+    # Format the last refresh date based on selected mailbox. If none is
+    # selected, the first one of the account will be used.
+    getFormattedDate: ->
+        if @props.selectedMailboxID?
+            mailbox = @props.mailboxes.get @props.selectedMailboxID
+        else
+            mailbox = @props.mailboxes.first()
+
+        date = mailbox.get 'lastSync'
+        formatter = 'DD/MM/YYYY HH:mm:ss'
+        formattedDate = moment(date).format formatter
+
+        return formattedDate
 
 
     # Trigger the refresh action.

--- a/client/app/locales/de.coffee
+++ b/client/app/locales/de.coffee
@@ -61,6 +61,7 @@ module.exports =
       "menu refresh initializing": "Initializing..."
       "menu refresh cleaning"   : "Cleaning..."
       "menu refresh indicator"  : "%{account}: %{mailbox} (%{progress}%)"
+      "menu last refresh"       : "Last refresh on %{date}."
 
       # List
       "list empty"              : "Keine E-Mail in diesem Postfach."

--- a/client/app/locales/en.coffee
+++ b/client/app/locales/en.coffee
@@ -61,6 +61,7 @@ module.exports =
       "menu refresh initializing": "Initializing..."
       "menu refresh cleaning"   : "Cleaning..."
       "menu refresh indicator"  : "%{account}: %{mailbox} (%{progress}%)"
+      "menu last refresh"       : "Last refresh on %{date}."
 
       # List
       "list empty"              : "No email in this box."

--- a/client/app/locales/fr.coffee
+++ b/client/app/locales/fr.coffee
@@ -61,6 +61,7 @@ module.exports =
       "menu refresh initializing": "Initialisation..."
       "menu refresh cleaning"   : "Nettoyage..."
       "menu refresh indicator"  : "%{account} : %{mailbox} (%{progress}%)"
+      "menu last refresh"       : "Dernier rafraîchissement le %{date}."
 
 
       # List

--- a/server/models/account.coffee
+++ b/server/models/account.coffee
@@ -372,6 +372,7 @@ class Account extends cozydb.CozyModel
                     nbTotal  : count?.total  or 0
                     nbUnread : count?.unread or 0
                     nbRecent : count?.recent or 0
+                    lastSync : box.lastSync
 
             callback null, rawObject
 

--- a/server/models/mailbox.coffee
+++ b/server/models/mailbox.coffee
@@ -12,6 +12,7 @@ class Mailbox extends cozydb.CozyModel
         delimiter: String        # delimiter between this box and its children
         uidvalidity: Number      # Imap UIDValidity
         attribs: [String]        # [String] Attributes of this folder
+        lastSync: String         # Date.ISOString of last full box synchro
 
     # map of account's attributes -> RFC6154 special use box attributes
     @RFC6154:


### PR DESCRIPTION
During review you will probably wonder why did I use `title` rather than a shiny tooltip. The reason is that tooltips with dynamic content are not possible right now with the way the application uses tooltips.

**Short answer**
We can't do tooltips with dynamic content right now due to the fact aria-tips changes the DOM and it messes React up. I can do something about it, but I feel like there are more important things to do.

**Long answer**
The tooltips library re-append all the element with `[role="tooltip"]` to `body` so it's relative to the body and not the parent's element it has been put in (thus, it's easier to position and animate). That means you break React's virtual dom, but that's okay when the tooltips never change.
When their content changes, it must be done the React way, with a source of truth you mutate. In our case, it would probably be a Flux store. That's a bit of work since I'm not a 100% sure of what to do.

Also fixed a bug in the initial state of the application (no account created yet).