### PR TITLE
Added: a placeholder string when the refresh indicator is in a weird state

### DIFF
--- a/client/app/components/menu_refresh_indicator.coffee
+++ b/client/app/components/menu_refresh_indicator.coffee
@@ -68,6 +68,12 @@ module.exports = React.createClass
                         else if @state.isRefreshStarted
                             span key: 'sync-box', t("menu refresh initializing")
 
+                        # This is a weird state that should not occur, why it
+                        # happens has not been figured out yet. A placeholder
+                        # string is used in the meantime.
+                        else
+                            span key: 'waiting', t("menu refresh waiting")
+
                 ]
 
 

--- a/client/app/locales/de.coffee
+++ b/client/app/locales/de.coffee
@@ -60,6 +60,7 @@ module.exports =
       "menu refresh label"      : "Refresh"
       "menu refresh initializing": "Initializing..."
       "menu refresh cleaning"   : "Cleaning..."
+      "menu refresh waiting"    : "Waiting for server..."
       "menu refresh indicator"  : "%{account}: %{mailbox} (%{progress}%)"
       "menu last refresh"       : "Last refresh on %{date}."
 

--- a/client/app/locales/en.coffee
+++ b/client/app/locales/en.coffee
@@ -60,6 +60,7 @@ module.exports =
       "menu refresh label"      : "Refresh"
       "menu refresh initializing": "Initializing..."
       "menu refresh cleaning"   : "Cleaning..."
+      "menu refresh waiting"    : "Waiting for server..."
       "menu refresh indicator"  : "%{account}: %{mailbox} (%{progress}%)"
       "menu last refresh"       : "Last refresh on %{date}."
 

--- a/client/app/locales/fr.coffee
+++ b/client/app/locales/fr.coffee
@@ -60,6 +60,7 @@ module.exports =
       "menu refresh label"      : "Rafraîchir"
       "menu refresh initializing": "Initialisation..."
       "menu refresh cleaning"   : "Nettoyage..."
+      "menu refresh waiting"    : "En attente du serveur..."
       "menu refresh indicator"  : "%{account} : %{mailbox} (%{progress}%)"
       "menu last refresh"       : "Dernier rafraîchissement le %{date}."
 


### PR DESCRIPTION
As you may have noticed during the demo, the refresh indicator sometimes only has a spinner with no text. I couldn't figured how the app managed to go in such state, so I added a placeholder "Waiting for server" so it doesn't feel too buggy for the release.