### PR TITLE
Minor fixes

### DIFF
--- a/client/app/actions/account_action_creator.coffee
+++ b/client/app/actions/account_action_creator.coffee
@@ -90,14 +90,15 @@ module.exports = AccountActionCreator =
 
     selectAccount: (accountID, mailboxID) ->
         changed = AccountStore.selectedIsDifferentThan accountID, mailboxID
-        selected = AccountStore.getSelected()
-        supportRFC4551 = selected?.get('supportRFC4551')
 
         AppDispatcher.handleViewAction
             type: ActionTypes.SELECT_ACCOUNT
             value:
                 accountID: accountID
                 mailboxID: mailboxID
+
+        selected = AccountStore.getSelected()
+        supportRFC4551 = selected?.get('supportRFC4551')
 
         if mailboxID? and changed and supportRFC4551
             MessageActionCreator.refreshMailbox(mailboxID)

--- a/client/app/actions/message_action_creator.coffee
+++ b/client/app/actions/message_action_creator.coffee
@@ -77,7 +77,7 @@ module.exports = MessageActionCreator =
                 value: {mailboxID}
 
             XHRUtils.refreshMailbox mailboxID, (error, updated) ->
-                if err?
+                if error?
                     AppDispatcher.handleViewAction
                         type: ActionTypes.REFRESH_FAILURE
                         value: {mailboxID, error}

--- a/client/app/utils/xhr_utils.coffee
+++ b/client/app/utils/xhr_utils.coffee
@@ -266,7 +266,7 @@ module.exports =
             if res.ok
                 callback null, res.text
             else
-                callback res.body
+                callback res.text
 
 
     activityCreate: (options, callback) ->


### PR DESCRIPTION
Commits description are self-explanatory.

A note about: "	Fixed: fast refresh could be done on an account that doesn't support it".
To reproduce the bug, the user must first select an account that support the RFC, then an account that doesn't support it.