### PR TITLE
Remove patchConversation

### DIFF
--- a/client/app/components/message.coffee
+++ b/client/app/components/message.coffee
@@ -153,7 +153,7 @@ module.exports = React.createClass
         messageDisplayHTML = true
         parser = new DOMParser()
         html   = """<html><head>
-                <link rel="stylesheet" href="/fonts/fonts.css" />
+                <link rel="stylesheet" href="./fonts/fonts.css" />
                 <link rel="stylesheet" href="./mail_stylesheet.css" />
                 <style>body { visibility: hidden; }</style>
             </head><body>#{html}</body></html>"""

--- a/server/controllers/accounts.coffee
+++ b/server/controllers/accounts.coffee
@@ -6,6 +6,8 @@ async = require 'async'
 notifications = require '../utils/notifications'
 ramStore = require '../models/store_account_and_boxes'
 Scheduler = require '../processes/_scheduler'
+MailboxRefresh = require '../processes/mailbox_refresh'
+patchConversation = require '../patchs/conversation'
 
 # create an account
 # and lauch fetching of this account mails
@@ -28,8 +30,37 @@ module.exports.create = (req, res, next) ->
 
     ], (err) ->
         return next err if err
+
         res.send ramStore.getAccountClientObject account.id
-        Scheduler.startAccountRefresh(account.id) # will start a refresh
+
+        favoriteBoxes = ramStore.getFavoriteMailboxesByAccount account.id
+        allBoxes = ramStore.getMailboxesByAccount account.id
+
+        # after the http request have been replied, fire up a refresh
+        # of this account
+        async.series [
+            # fetch 100 messages for each box
+            (cb) ->
+                refreshes = favoriteBoxes.map (mailbox) ->
+                    new MailboxRefresh {mailbox, limitByBox: 100}
+
+                Scheduler.scheduleMultiple refreshes, cb
+
+            # fetch all the other messages (very long)
+            (cb) ->
+                refreshes = allBoxes.map (mailbox) ->
+                        new MailboxRefresh {mailbox}
+
+                Scheduler.scheduleMultiple refreshes, cb
+
+            # message fetched in first refresh might not be in proper conv
+            # @TODO : apply patch only to messages from first refresh ?
+            (cb) ->
+                patchConversation.patchOneAccount account, callback
+
+        ], (err) ->
+            log.error err if err
+            log.info "Account #{account?.label} import complete"
 
 # check account parameters
 module.exports.check = (req, res, next) ->

--- a/server/processes/_scheduler.coffee
+++ b/server/processes/_scheduler.coffee
@@ -85,24 +85,7 @@ Scheduler.onIdle = ->
         log.debug "nothing to do, waiting 10 MIN"
         setTimeout Scheduler.doNext, 10 * MIN
 
-    # called after account creation
-Scheduler.startAccountRefresh = (accountID, done) ->
-    log.debug "Scheduler.startAccountRefresh"
-
-    processes = ramStore.getFavoriteMailboxesByAccount accountID
-        .map (mailbox) -> new MailboxRefresh {mailbox, limitByBox: 100}
-
-    Scheduler.scheduleMultiple processes, (err) ->
-        log.error err if err
-
-        processes = ramStore.getMailboxesByAccount accountID
-            .map (mailbox) -> new MailboxRefresh {mailbox}
-
-        Scheduler.scheduleMultiple processes, (err) ->
-            log.error err if err
-            done? err
-
-    # called by the Scheduler every hour
+# called by the Scheduler every hour
 Scheduler.startAllRefresh = (done) ->
     log.debug "Scheduler.startAllRefresh"
 
@@ -122,7 +105,7 @@ Scheduler.startAllRefresh = (done) ->
             lastAllRefresh = Date.now()
             done? err
 
-    # called by the Scheduler every 5Min
+# called by the Scheduler every 5Min
 Scheduler.startFavoriteRefresh = ->
     log.debug "Scheduler.startFavoriteRefresh"
     processes = ramStore.getFavoriteMailboxes()

--- a/server/processes/application_startup.coffee
+++ b/server/processes/application_startup.coffee
@@ -1,6 +1,5 @@
 Process = require './_base'
 OrphanRemoval = require './orphan_removal'
-patchConversation = require '../patchs/conversation'
 patchIgnored = require '../patchs/ignored'
 log = require('../utils/logging')(prefix: 'process:application_startup')
 ramStore = require '../models/store_account_and_boxes'
@@ -21,7 +20,6 @@ module.exports = class ApplicationStartup extends Process
             @forceCozyDBReindexing
             ramStore.initialize
             @initializeNewAccounts
-            patchConversation.patchAllAccounts
             patchIgnored.patchAllAccounts
             @removeOrphans
         ], callback

--- a/server/processes/mailbox_refresh_deep.coffee
+++ b/server/processes/mailbox_refresh_deep.coffee
@@ -6,14 +6,13 @@ log = require('../utils/logging')(prefix: 'process:box_refresh_deep')
 {RefreshError} = require '../utils/errors'
 _ = require 'lodash'
 Message = require '../models/message'
-patchConversation = require '../patchs/conversation'
 ramStore = require '../models/store_account_and_boxes'
 
 
 # This process perform the deep refresh of one mailbox
 #
 # options
-#  :limitbybox
+#  :limitByBox
 #  :firstImport
 #  :storeHighestModSeq
 #  :mailbox
@@ -60,7 +59,6 @@ module.exports = class MailboxRefreshDeep extends Process
             @applyToRemove
             @applyFlagsChanges
             @applyToFetch
-            @convPatch
         ], callback
 
     getProgress: =>
@@ -84,28 +82,33 @@ module.exports = class MailboxRefreshDeep extends Process
     # Returns (void)
     setNextStep: (uidnext) =>
         log.debug "computeNextStep", @status(), "next", uidnext
-        if @initialStep
-            # pretend the last step was max: INFINITY, min: uidnext
-            @min = uidnext + 1
 
-        if @min is 1
-            # uid are always > 1, we are done
+        if @limitByBox and not @initialStep
+            # the first step has the proper limitByBox size, we are done
             @finished = true
 
-        if @limitByBox
+        else if @limitByBox
+            # GET @limitByBox from the end of the box
+            @initialStep = false
             @nbStep = 1
-            range = @limitByBox
-            unless @initialStep
-                # the first step has the proper limitByBox size, we are done
-                @finished = true
-        else
-            @nbStep = Math.ceil uidnext / FETCH_AT_ONCE
-            range = FETCH_AT_ONCE
+            @min = Math.max 1, uidnext - @limitByBox
+            @max = Math.max 1, uidnext - 1
 
-        @initialStep = false
-        @max = Math.max 1, @min - 1
-        # new min is old min - range
-        @min = Math.max 1, @min - range
+        else if @initialStep
+            # first step, 1:FETCH_AT_ONCE
+            @initialStep = false
+            @nbStep = Math.ceil uidnext / FETCH_AT_ONCE
+            @min = 1
+            @max = Math.min uidnext, FETCH_AT_ONCE
+
+        else
+            # next steps, increase all by FETCH_AT_ONCE
+            @min = Math.min uidnext, @max + 1
+            @max = Math.min uidnext, @min + FETCH_AT_ONCE
+
+        if @min is @max
+            @finished = true
+
         log.debug "nextStepEnd", @status()
 
     UIDsInRange: (callback) ->
@@ -241,11 +244,6 @@ module.exports = class MailboxRefreshDeep extends Process
         , (errors) ->
             if errors?.length then callback new RefreshError errors
             else callback null
-
-    convPatch: (callback) =>
-        return callback null if @finished
-        account = id: @mailbox.accountID
-        patchConversation.patchOneAccount account, callback
 
     saveLastSync: (callback) =>
         changes = lastSync: new Date().toISOString()


### PR DESCRIPTION
By fetching messages in the proper order (oldest first), we avoid the need for patch conversation (except after first import).

Also included : dont use the proxy CDN fonts to prevent flash of fonts (ref : https://github.com/cozy/cozy-proxy/pull/166)