### PR TITLE
Fix Gmail security

### DIFF
--- a/client/app/components/account_config_main.coffee
+++ b/client/app/components/account_config_main.coffee
@@ -21,6 +21,8 @@ SMTP_OPTIONS =
     'LOGIN': t("account smtpMethod LOGIN")
     'PLAIN': t("account smtpMethod PLAIN")
 
+GOOGLE_IMAP = ['imap.googlemail.com', 'imap.gmail.com']
+
 module.exports = AccountConfigMain = React.createClass
     displayName: 'AccountConfigMain'
 
@@ -192,13 +194,20 @@ module.exports = AccountConfigMain = React.createClass
 
     _renderGMAILSecurity: ->
         url = "https://www.google.com/settings/security/lesssecureapps"
+        login = @props.editedAccount.get('login')
         FieldSet text: t('gmail security tile'),
-            p null, t('gmail security body', login: @state.login.value)
+            p null, t('gmail security body', {login})
             p null,
                 a
                     target: '_blank',
                     href: url
                     t 'gmail security link'
+            p null, t('gmail security body 2')
+            p null,
+                a
+                    target: '_blank'
+                    href: 'https://accounts.google.com/DisplayUnlockCaptcha'
+                    t 'gmail security link 2'
 
     _renderButtons: ->
         if @props.errors.length is 0
@@ -249,7 +258,7 @@ module.exports = AccountConfigMain = React.createClass
             unless err
                 infos = discovery2Fields provider
                 # Display gmail warning if selected provider is Gmail.
-                isGmail = infos.imapServer is 'imap.googlemail.com'
+                isGmail = infos.imapServer in GOOGLE_IMAP
                 @setState displayGMAILSecurity: isGmail
 
                 @props.requestChange infos

--- a/client/app/locales/en.json
+++ b/client/app/locales/en.json
@@ -333,7 +333,7 @@
   "gmail security tile": "About Gmail security",
   "gmail security body": "Gmail considers connection using username and password not safe.\nPlease click on the following link, make sure\nyou are connected with your %{login} account and enable access for\nless secure apps.",
   "gmail security link": "Enable access for less secure apps.",
-  "gmail security body 2": "If you still cant connect, you might need to use the unlock captcha from the following link.",
+  "gmail security body 2": "If you still can't connect, you might need to use the unlock captcha from the following link.",
   "gmail security link 2": "Display unlock captcha.",
   "plugin name Gallery": "Attachment gallery",
   "plugin name medium-editor": "Medium editor",

--- a/client/app/locales/en.json
+++ b/client/app/locales/en.json
@@ -333,6 +333,8 @@
   "gmail security tile": "About Gmail security",
   "gmail security body": "Gmail considers connection using username and password not safe.\nPlease click on the following link, make sure\nyou are connected with your %{login} account and enable access for\nless secure apps.",
   "gmail security link": "Enable access for less secure apps.",
+  "gmail security body 2": "If you still cant connect, you might need to use the unlock captcha from the following link.",
+  "gmail security link 2": "Display unlock captcha.",
   "plugin name Gallery": "Attachment gallery",
   "plugin name medium-editor": "Medium editor",
   "plugin name MiniSlate": "MiniSlate editor",


### PR DESCRIPTION
The imap server returned by autoconfig has changed, so we lost the security warning for gmail.

Also added some explanations about the rare(r) case, where the user need to display the gmail unlock captcha even if they have activated access for less secure app.