### PR TITLE
Autosave create un-useless draft 

### DIFF
--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -58,8 +58,6 @@ module.exports = Compose = React.createClass
 
         classLabel = 'compose-label'
         classInput = 'compose-input'
-        classCc    = if @state.ccShown  then ' shown ' else ''
-        classBcc   = if @state.bccShown then ' shown ' else ''
 
         focusEditor = Array.isArray(@state.to) and
             @state.to.length > 0 and
@@ -89,11 +87,13 @@ module.exports = Compose = React.createClass
                             div null
                                 a
                                     className: 'compose-toggle-cc',
-                                    onClick: @onToggleCc,
+                                    onClick: @toggleField,
+                                    'data-ref': 'cc'
                                     t 'compose toggle cc'
                                 a
                                     className: 'compose-toggle-bcc',
-                                    onClick: @onToggleBcc,
+                                    onClick: @toggleField,
+                                    'data-ref': 'bcc'
                                     t 'compose toggle bcc'
 
                 MailsInput
@@ -104,7 +104,7 @@ module.exports = Compose = React.createClass
 
                 MailsInput
                     id: 'compose-cc'
-                    className: 'compose-cc' + classCc
+                    className: 'compose-cc'
                     valueLink: @linkState 'cc'
                     label: t 'compose cc'
                     placeholder: t 'compose cc help'
@@ -112,7 +112,7 @@ module.exports = Compose = React.createClass
 
                 MailsInput
                     id: 'compose-bcc'
-                    className: 'compose-bcc' + classBcc
+                    className: 'compose-bcc'
                     valueLink: @linkState 'bcc'
                     label: t 'compose bcc'
                     placeholder: t 'compose bcc help'
@@ -315,8 +315,6 @@ module.exports = Compose = React.createClass
 
         state.isDraft  = true
 
-        state.ccShown  = Array.isArray(state.cc) and state.cc.length > 0
-        state.bccShown = Array.isArray(state.bcc) and state.bcc.length > 0
         # save initial message content, to don't ask confirmation if
         # it has not been updated
         state.initHtml = state.html
@@ -421,19 +419,10 @@ module.exports = Compose = React.createClass
             actionLabel : t 'mail confirm delete delete'
         , doDelete
 
-    onToggleCc: (e) ->
-        toggle = (e) -> e.classList.toggle 'shown'
-        toggle e for e in @getDOMNode().querySelectorAll '.compose-cc'
-        focus = if not @state.ccShown then 'cc' else ''
-        @setState ccShown: not @state.ccShown, focus: focus
-
-
-    onToggleBcc: (e) ->
-        toggle = (e) -> e.classList.toggle 'shown'
-        toggle e for e in @getDOMNode().querySelectorAll '.compose-bcc'
-        focus = if not @state.bccShown then 'bcc' else ''
-        @setState bccShown: not @state.bccShown, focus: focus
-
+    toggleField: (event) ->
+        target = event.currentTarget.getAttribute 'data-ref'
+        element = @refs[target].getDOMNode()
+        element.classList.toggle 'shown'
 
     # Get the file picker component (method used to pass it to the editor)
     getPicker: ->

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -51,6 +51,7 @@ module.exports = Compose = React.createClass
         layout: 'full'
 
     shouldComponentUpdate: (nextProps, nextState) ->
+        nextState.attachments = Immutable.Vector.from nextState.attachments
         !!nextProps.accounts
 
     render: ->

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -59,18 +59,6 @@ module.exports = Compose = React.createClass
     shouldComponentUpdate: (nextProps, nextState) ->
         !!nextProps.accounts
 
-    componentWillReceiveProps: (nextProps) ->
-        if nextProps.message
-            # Save current message
-            @closeSaveDraft @state,
-                silent: true
-                hasChanged: @hasChanged @props, @state
-
-            # Display another message
-            state = MessageUtils.createBasicMessage nextProps
-            @setState state
-
-
     componentWillUpdate: (nextProps, nextState) ->
         unless _.isEmpty (text = nextState.text.trim())
             if nextState.composeInHTML

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -205,11 +205,6 @@ module.exports = Compose = React.createClass
 
 
     componentDidMount: ->
-        # Initialize @state
-        # with values from server
-        if @props.settings.get 'autosaveDraft'
-            @saveDraft()
-
         # scroll compose window into view
         @getDOMNode().scrollIntoView()
 
@@ -222,6 +217,11 @@ module.exports = Compose = React.createClass
             document.getElementById('compose-editor')?.focus()
 
     componentDidUpdate: ->
+        # Initialize @state
+        # with values from server
+        if @props.settings.get('autosaveDraft') and not @state.id
+            @saveDraft()
+
         # focus
         switch @state.focus
             when 'cc'

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -256,6 +256,8 @@ module.exports = Compose = React.createClass
         LayoutActionCreator.displayModal params
 
     componentWillUnmount: ->
+        return if @props.lastUpdate is @state.date
+
         doSave = =>
             LayoutActionCreator.hideModal()
             MessageActionCreator.send @state, (error, message) ->
@@ -357,6 +359,7 @@ module.exports = Compose = React.createClass
         message = _.clone @state
 
         @props.isSaving = true
+        @props.lastUpdate = message.date
         MessageActionCreator.send message, (error, message) =>
             if error? or not message?
                 if @state.isDraft

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -111,7 +111,9 @@ module.exports = Compose = React.createClass
         delete @props.lastUpdate
 
     componentWillUnmount: ->
-        @closeSaveDraft @state, hasChanged: @hasChanged(@props, @state)
+        @closeSaveDraft @state,
+            hasChanged: @hasChanged(@props, @state)
+            silent: true
 
     closeSaveDraft: (state, options={}) ->
         fetch = (error, message) =>

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -340,7 +340,7 @@ module.exports = Compose = React.createClass
                 composeInHTML: @props.settings.get 'composeInHTML'
                 isNew: false
             if (not message.get('html')?) and message.get('text')
-                state.conposeInHTML = false
+                state.composeInHTML = false
 
             # TODO : smarter ?
             state[key] = value for key, value of message.toJS()

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -344,14 +344,12 @@ module.exports = Compose = React.createClass
     validateMessage: ->
         return if @state.isDraft
         error =
-            'dest': ['to', 'cc', 'bcc']
-            'subject': ['subject']
-        getGroupedError error, @state
+            'dest': ['to']
+        getGroupedError error, @state, _.isEmpty
 
     sendActionMessage: (success) ->
         return if @props.isSaving
         if (validate = @validateMessage())
-            console.log 'ERROR', validate
             LayoutActionCreator.alertError t 'compose error no ' + validate[1]
             success() if _.isFunction success
             return
@@ -456,12 +454,12 @@ cleanHTML = (html) ->
         console.error "Unable to parse HTML content of message"
         return html
 
-getGroupedError = (error, message) ->
+getGroupedError = (error, message, test) ->
     type = null
     group = null
     _.find error, (properties, key) ->
         type = _.find properties, (property) ->
-            _.isEmpty message[property]
+            test message[property]
         group = key if type?
         type
     if type or group then [type, group] else null

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -213,14 +213,6 @@ module.exports = Compose = React.createClass
 
     _initCompose: ->
 
-        if @_saveInterval
-            window.clearInterval @_saveInterval
-
-        @_saveInterval = window.setInterval @_autosave, 30000
-
-        # First save of draft
-        @_autosave()
-
         # scroll compose window into view
         @getDOMNode().scrollIntoView()
 
@@ -236,8 +228,12 @@ module.exports = Compose = React.createClass
     componentDidMount: ->
         @_initCompose()
 
+        setTimeout @_autosave, 30000
+
 
     componentDidUpdate: ->
+        setTimeout @_autosave, 30000
+
         switch @state.focus
             when 'cc'
                 setTimeout ->
@@ -253,9 +249,6 @@ module.exports = Compose = React.createClass
 
 
     componentWillUnmount: ->
-        if @_saveInterval
-            window.clearInterval @_saveInterval
-
         # delete draft
         doDelete = =>
             window.setTimeout =>
@@ -444,9 +437,6 @@ module.exports = Compose = React.createClass
                 message.html = MessageUtils.wrapReplyHtml message.html
             else
                 message.text = @state.text.trim()
-
-            if not isDraft and @_saveInterval
-                window.clearInterval @_saveInterval
 
             if isDraft
                 @setState saving: true

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -419,7 +419,7 @@ module.exports = Compose = React.createClass
     toggleField: (event) ->
         ref = event.currentTarget.getAttribute 'data-ref'
         view = @refs[ref]
-        value = !!!view.state.focus
+        value = !view.state.focus
 
         view.setState focus: value
 

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -50,10 +50,10 @@ module.exports = Compose = React.createClass
     getDefaultProps: ->
         layout: 'full'
 
+    shouldComponentUpdate: (nextProps, nextState) ->
+        !!nextProps.accounts
 
     render: ->
-        return unless @props.accounts
-
         closeUrl = @buildClosePanelUrl @props.layout
 
         classLabel = 'compose-label'

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -51,11 +51,6 @@ module.exports = Compose = React.createClass
         layout: 'full'
 
 
-    shouldComponentUpdate: (nextProps, nextState) ->
-        return not(_.isEqual(nextState, @state)) or
-            not (_.isEqual(nextProps, @props))
-
-
     render: ->
         return unless @props.accounts
 

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -64,12 +64,12 @@ module.exports = Compose = React.createClass
 
     componentWillUpdate: (nextProps, nextState) ->
         nextState.attachments = Immutable.Vector.from nextState.attachments
-        if nextState.composeInHTML
-            nextState.html = MessageUtils.cleanHTML nextState.html
-            nextState.text = MessageUtils.cleanReplyText nextState.html
-            nextState.html = MessageUtils.wrapReplyHtml nextState.html
-        else
-            nextState.text = nextState.text.trim()
+
+        unless _.isEmpty (text = nextState.text.trim())
+            if nextState.composeInHTML
+                nextState.html = MessageUtils.cleanHTML nextState.html
+                nextState.text = MessageUtils.cleanReplyText nextState.html
+                nextState.html = MessageUtils.wrapReplyHtml nextState.html
 
     componentDidMount: ->
         # scroll compose window into view

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -426,9 +426,11 @@ module.exports = Compose = React.createClass
         , doDelete
 
     toggleField: (event) ->
-        target = event.currentTarget.getAttribute 'data-ref'
-        element = @refs[target].getDOMNode()
-        element.classList.toggle 'shown'
+        ref = event.currentTarget.getAttribute 'data-ref'
+        view = @refs[ref]
+        value = !!!view.state.focus
+
+        view.setState focus: value
 
     # Get the file picker component (method used to pass it to the editor)
     getPicker: ->

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -54,10 +54,7 @@ module.exports = Compose = React.createClass
         MessageUtils.makeReplyMessage @props
 
     isNew: ->
-        not @state.originalConversationID
-
-    unsetNew: ->
-        @state.originalConversationID = @state.conversationID
+        not @state.conversationID
 
     shouldComponentUpdate: (nextProps, nextState) ->
         !!nextProps.accounts
@@ -384,10 +381,6 @@ module.exports = Compose = React.createClass
                 _.each _keys, (key) =>
                     if _.isUndefined @state[key]
                         @state[key] = message[key]
-
-            # use another field to prevent the empty conversationID of draft
-            # to override the original conversationID
-            @unsetNew() if @isNew()
 
             # TODO : move this into render
             unless @state.isDraft

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -207,7 +207,7 @@ module.exports = Compose = React.createClass
                     valueLink: @linkState 'to'
                     label: t 'compose to'
                     ref: 'to'
-                        key: 'to-' + prefixKey
+                    key: 'to-' + prefixKey
 
                 MailsInput
                     id: 'compose-cc'

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -261,9 +261,9 @@ module.exports = Compose = React.createClass
     # selection and message information.
     finalRedirect: ->
         if @props.inReplyTo?
-            conversationID = @props.inReplyTo.get('conversationID')
-            accountID = @props.inReplyTo.get('accountID')
-            messageID = @props.inReplyTo.get('id')
+            conversationID = @state.conversationID
+            accountID = @props.selectedAccountID
+            messageID = @state.id
             mailboxes = Object.keys @props.inReplyTo.get 'mailboxIDs'
             mailboxID = AccountStore.pickBestBox accountID, mailboxes
 

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -57,7 +57,7 @@ module.exports = Compose = React.createClass
         not @state.conversationID
 
     shouldComponentUpdate: (nextProps, nextState) ->
-        !!nextProps.accounts
+        not _.isEqual nextState, @state
 
     componentWillUpdate: (nextProps, nextState) ->
         unless _.isEmpty (text = nextState.text.trim())

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -311,13 +311,13 @@ module.exports = Compose = React.createClass
         event.preventDefault() if event?
         @state.isDraft = true
         @sendActionMessage =>
-            @refs.toolbox.setState action: null
+            @refs.toolbox.setState action: null if @refs.toolbox
 
     sendMessage: (event) ->
         event.preventDefault() if event?
         @state.isDraft = false
         @sendActionMessage =>
-            @refs.toolbox.setState action: null
+            @refs.toolbox.setState action: null if @refs.toolbox
 
     validateMessage: ->
         return if @state.isDraft

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -157,7 +157,6 @@ module.exports = Compose = React.createClass
                     save()
         setTimeout init, 0
 
-
     render: ->
         closeUrl = @buildClosePanelUrl @props.layout
 
@@ -307,11 +306,10 @@ module.exports = Compose = React.createClass
                 @props.selectedMailboxID
             ]
 
-    # Cancel brings back to default view. If it's while replying to a message,
+    # Cancel brings back to default view.
+    # If it's while replying to a message,
     # it brings back to this message.
     close: (event) ->
-        event.preventDefault()
-
         # Action after cancelation: call @props.onCancel
         # or navigate to message list.
         if @props.onCancel?

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -206,7 +206,8 @@ module.exports = Compose = React.createClass
             @finalRedirect()
 
 
-    _initCompose: ->
+    componentDidMount: ->
+        setTimeout @_autosave, 30000
 
         # scroll compose window into view
         @getDOMNode().scrollIntoView()
@@ -218,12 +219,6 @@ module.exports = Compose = React.createClass
             , 10
         else if @props.inReplyTo?
             document.getElementById('compose-editor')?.focus()
-
-
-    componentDidMount: ->
-        @_initCompose()
-
-        setTimeout @_autosave, 30000
 
 
     componentDidUpdate: ->

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -51,7 +51,7 @@ module.exports = Compose = React.createClass
         layout: 'full'
 
     getInitialState: ->
-        MessageUtils.makeReplyMessage @props
+        MessageUtils.createBasicMessage @props
 
     isNew: ->
         not @state.conversationID
@@ -67,7 +67,7 @@ module.exports = Compose = React.createClass
                 hasChanged: @hasChanged @props, @state
 
             # Display another message
-            state = MessageUtils.makeReplyMessage nextProps
+            state = MessageUtils.createBasicMessage nextProps
             @setState state
 
 

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -63,8 +63,6 @@ module.exports = Compose = React.createClass
         !!nextProps.accounts
 
     componentWillUpdate: (nextProps, nextState) ->
-        nextState.attachments = Immutable.Vector.from nextState.attachments
-
         unless _.isEmpty (text = nextState.text.trim())
             if nextState.composeInHTML
                 nextState.html = MessageUtils.cleanHTML nextState.html
@@ -339,7 +337,7 @@ module.exports = Compose = React.createClass
 
         @props.isSaving = true
         @props.lastUpdate = @state.date
-        MessageActionCreator.send @state, (error, message) =>
+        MessageActionCreator.send _.clone(@state), (error, message) =>
             if error? or not message?
                 if @state.isDraft
                     msgKo = t "message action draft ko"
@@ -364,6 +362,7 @@ module.exports = Compose = React.createClass
             # use another field to prevent the empty conversationID of draft
             # to override the original conversationID
             @unsetNew() if @isNew()
+
 
             # TODO : move this into render
             unless @state.isDraft

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -163,6 +163,7 @@ module.exports = Compose = React.createClass
 
         classLabel = 'compose-label'
         classInput = 'compose-input'
+        prefixKey = @state.id or 'new'
 
         focusEditor = Array.isArray(@state.to) and
             @state.to.length > 0 and
@@ -206,6 +207,7 @@ module.exports = Compose = React.createClass
                     valueLink: @linkState 'to'
                     label: t 'compose to'
                     ref: 'to'
+                        key: 'to-' + prefixKey
 
                 MailsInput
                     id: 'compose-cc'
@@ -214,6 +216,7 @@ module.exports = Compose = React.createClass
                     label: t 'compose cc'
                     placeholder: t 'compose cc help'
                     ref: 'cc'
+                    key: 'cc-' + prefixKey
 
                 MailsInput
                     id: 'compose-bcc'
@@ -222,6 +225,7 @@ module.exports = Compose = React.createClass
                     label: t 'compose bcc'
                     placeholder: t 'compose bcc help'
                     ref: 'bcc'
+                    key: 'bcc-' + prefixKey
 
                 div className: 'form-group',
                     div className: classInput,
@@ -245,10 +249,10 @@ module.exports = Compose = React.createClass
                         settings          : @props.settings
                         onSend            : @sendMessage
                         composeInHTML     : @state.composeInHTML
-                        focus             : focusEditor
-                        ref               : 'editor'
                         getPicker         : @getPicker
                         useIntents        : @props.useIntents
+                        ref               : 'editor'
+                        key               : 'editor-' + prefixKey
 
                 div className: 'attachements',
                     FilePicker
@@ -256,6 +260,7 @@ module.exports = Compose = React.createClass
                         editable: true
                         valueLink: @linkState 'attachments'
                         ref: 'attachments'
+                        key: 'attachments-' + prefixKey
 
                 ComposeToolbox
                     send      : @sendMessage
@@ -263,7 +268,8 @@ module.exports = Compose = React.createClass
                     save      : @saveDraft
                     cancel    : @close
                     canDelete : @state.id?
-                    ref: 'toolbox'
+                    ref       : 'toolbox'
+                    ref       : 'toolbox-' + prefixKey
 
                 div className: 'clearfix', null
 

--- a/client/app/components/compose_editor.coffee
+++ b/client/app/components/compose_editor.coffee
@@ -16,10 +16,6 @@ module.exports = ComposeEditor = React.createClass
             target: false     # true when hovering with a file
         }
 
-    componentWillReceiveProps: (nextProps) ->
-        if nextProps.messageID isnt @props.messageID
-            @setState html: nextProps.html, text: nextProps.text
-
     shouldComponentUpdate: (nextProps, nextState) ->
         return not(_.isEqual(nextState, @state)) or
             not (_.isEqual(nextProps, @props))
@@ -406,4 +402,3 @@ module.exports = ComposeEditor = React.createClass
                             editor.appendChild img
                 # force update of React component
                 @onHTMLChange()
-

--- a/client/app/components/compose_toolbox.coffee
+++ b/client/app/components/compose_toolbox.coffee
@@ -26,8 +26,8 @@ module.exports = ComposeToolbox = React.createClass
 
     triggerAction: (type) ->
         @setState action : type
-        if (callback = @props[type]) and _.isFunction callback
-            callback()
+        if (listener = @props[type]) and _.isFunction listener
+            listener?()
 
     render: ->
         div className: 'composeToolbox',

--- a/client/app/components/compose_toolbox.coffee
+++ b/client/app/components/compose_toolbox.coffee
@@ -5,31 +5,61 @@
 module.exports = ComposeToolbox = React.createClass
     displayName: 'ComposeToolbox'
 
-    render: ->
-        labelSend = t 'compose action send'
+    getInitialState: ->
+        action: null
 
+    getLabel: ->
+        className = if @state.action is 'send' then 'sending' else 'send'
+        t 'compose action ' + className
+
+    save: ->
+        @triggerAction 'save'
+
+    send: ->
+        @triggerAction 'send'
+
+    delete: ->
+        @triggerAction 'delete'
+
+    cancel: ->
+        @triggerAction 'cancel'
+
+    triggerAction: (type) ->
+        @setState action : type
+        if (callback = @props[type]) and _.isFunction callback
+            callback()
+
+    render: ->
         div className: 'composeToolbox',
             div className: 'btn-toolbar', role: 'toolbar',
                 div className: '',
                     button
                         className: 'btn btn-cozy btn-send',
                         type: 'button',
-                        onClick: @props.onSend,
+                        disable: if @state.action is 'send' then true else null
+                        onClick: @send,
+                            if @state.action is 'send'
+                                span null, Spinner(color: 'white')
+                            else
                                 span className: 'fa fa-send'
-                            span null, labelSend
+                            span null, @getLabel()
                     button
                         className: 'btn btn-cozy btn-save',
-                        type: 'button', onClick: @props.onDraft,
+                        disable: if @state.action is 'save' then true else null
+                        type: 'button', onClick: @save,
+                            if @state.action is 'save'
+                                span null, Spinner(color: 'white')
+                            else
                                 span className: 'fa fa-save'
                             span null, t 'compose action draft'
                     if @props.canDelete
                         button
                             className: 'btn btn-cozy-non-default btn-delete',
                             type: 'button',
-                            onClick: @props.onDelete,
+                            onClick: @delete,
                                 span className: 'fa fa-trash-o'
                                 span null, t 'compose action delete'
                     button
-                        onClick: @props.onCancel
+                        onClick: @props.cancel
                         className: 'btn btn-cozy-non-default btn-cancel',
                         t 'app cancel'

--- a/client/app/components/compose_toolbox.coffee
+++ b/client/app/components/compose_toolbox.coffee
@@ -12,22 +12,25 @@ module.exports = ComposeToolbox = React.createClass
         className = if @state.action is 'send' then 'sending' else 'send'
         t 'compose action ' + className
 
-    save: ->
+    save: (event) ->
+        event.preventDefault() if event
         @triggerAction 'save'
 
-    send: ->
+    send: (event) ->
+        event.preventDefault() if event
         @triggerAction 'send'
 
-    delete: ->
+    delete: (event) ->
+        event.preventDefault() if event
         @triggerAction 'delete'
 
-    cancel: ->
+    cancel: (event) ->
+        event.preventDefault() if event
         @triggerAction 'cancel'
 
     triggerAction: (type) ->
         @setState action : type
-        if (listener = @props[type]) and _.isFunction listener
-            listener?()
+        listener?() if (listener = @props[type])
 
     render: ->
         div className: 'composeToolbox',
@@ -60,6 +63,6 @@ module.exports = ComposeToolbox = React.createClass
                                 span className: 'fa fa-trash-o'
                                 span null, t 'compose action delete'
                     button
-                        onClick: @props.cancel
+                        onClick: @cancel
                         className: 'btn btn-cozy-non-default btn-cancel',
                         t 'app cancel'

--- a/client/app/components/compose_toolbox.coffee
+++ b/client/app/components/compose_toolbox.coffee
@@ -5,12 +5,8 @@
 module.exports = ComposeToolbox = React.createClass
     displayName: 'ComposeToolbox'
 
-
     render: ->
-        if @props.sending
-            labelSend = t 'compose action sending'
-        else
-            labelSend = t 'compose action send'
+        labelSend = t 'compose action send'
 
         div className: 'composeToolbox',
             div className: 'btn-toolbar', role: 'toolbar',
@@ -18,20 +14,12 @@ module.exports = ComposeToolbox = React.createClass
                     button
                         className: 'btn btn-cozy btn-send',
                         type: 'button',
-                        disable: if @props.sending then true else null
                         onClick: @props.onSend,
-                            if @props.sending
-                                span null, Spinner(color: 'white')
-                            else
                                 span className: 'fa fa-send'
                             span null, labelSend
                     button
                         className: 'btn btn-cozy btn-save',
-                        disable: if @props.saving then true else null
                         type: 'button', onClick: @props.onDraft,
-                            if @props.saving
-                                span null, Spinner(color: 'white')
-                            else
                                 span className: 'fa fa-save'
                             span null, t 'compose action draft'
                     if @props.canDelete

--- a/client/app/components/file_picker.coffee
+++ b/client/app/components/file_picker.coffee
@@ -48,13 +48,11 @@ FilePicker = React.createClass
             requestChange: ->
 
     getInitialState: ->
-        value = @props.value or @props.valueLink.value
-        files: Immutable.Vector.from value
+        files: @props.value or @props.valueLink.value
         target: false
 
     componentWillReceiveProps: (props) ->
-        value = props.value or props.valueLink.value
-        @setState files: Immutable.Vector.from value
+        @setState files: props.value or props.valueLink.value
 
     addFiles: (files) ->
         files = (@_fromDOM file for file in files)

--- a/client/app/components/file_picker.coffee
+++ b/client/app/components/file_picker.coffee
@@ -48,11 +48,13 @@ FilePicker = React.createClass
             requestChange: ->
 
     getInitialState: ->
-        files: @props.value or @props.valueLink.value
+        value = @props.value or @props.valueLink.value
+        files: Immutable.Vector.from value
         target: false
 
     componentWillReceiveProps: (props) ->
-        @setState files: props.value or props.valueLink.value
+        value = props.value or props.valueLink.value
+        @setState files: Immutable.Vector.from value
 
     addFiles: (files) ->
         files = (@_fromDOM file for file in files)
@@ -64,7 +66,6 @@ FilePicker = React.createClass
         files = @state.files.filter (f) ->
             f.get('generatedFileName') isnt file.generatedFileName
         .toVector()
-
         @props.valueLink.requestChange files
 
     displayFile: (file) ->

--- a/client/app/components/mails_input.coffee
+++ b/client/app/components/mails_input.coffee
@@ -127,6 +127,9 @@ module.exports = MailsInput = React.createClass
             else
                 event.dataTransfer.dropEffect = 'none'
 
+        # Show field if results
+        className += ' shown' unless _.isEmpty knownContacts
+
         # don't display placeholder if there are dests
         if knownContacts.length > 0
             placeholder = ''

--- a/client/app/components/mails_input.coffee
+++ b/client/app/components/mails_input.coffee
@@ -128,13 +128,10 @@ module.exports = MailsInput = React.createClass
                 event.dataTransfer.dropEffect = 'none'
 
         # Show field if results
-        className += ' shown' unless _.isEmpty knownContacts
+        className += ' shown' unless (hasNoContact = _.isEmpty knownContacts)
 
         # don't display placeholder if there are dests
-        if knownContacts.length > 0
-            placeholder = ''
-        else
-            placeholder = @props.placeholder
+        placeholder = unless hasNoContact then '' else @props.placeholder
 
         div
             className: className,

--- a/client/app/components/mails_input.coffee
+++ b/client/app/components/mails_input.coffee
@@ -28,10 +28,6 @@ module.exports = MailsInput = React.createClass
         state.focus    = !!state.known.length
         return state
 
-    componentWillReceiveProps: (nextProps) ->
-        value = nextProps.valueLink.value
-        @setState known: value, focus: not _.isEmpty value
-
     # Code from the StoreWatch Mixin. We don't use the mixin
     # because we store other things into the state
     componentDidMount: ->

--- a/client/app/components/mails_input.coffee
+++ b/client/app/components/mails_input.coffee
@@ -29,8 +29,8 @@ module.exports = MailsInput = React.createClass
         return state
 
     componentWillReceiveProps: (nextProps) ->
-        isFocus = _.isEmpty nextProps.valueLink.value
-        @setState known: value, focus: not isFocus
+        value = nextProps.valueLink.value
+        @setState known: value, focus: not _.isEmpty value
 
     # Code from the StoreWatch Mixin. We don't use the mixin
     # because we store other things into the state

--- a/client/app/components/mails_input.coffee
+++ b/client/app/components/mails_input.coffee
@@ -133,7 +133,7 @@ module.exports = MailsInput = React.createClass
 
         # don't display placeholder if there are dests
         hasNoContact = _.isEmpty knownContacts
-        placeholder = unless hasNoContact then '' else @props.placeholder
+        placeholder = if hasNoContact then @props.placeholder else ''
 
         div
             className: className,

--- a/client/app/components/mails_input.coffee
+++ b/client/app/components/mails_input.coffee
@@ -29,8 +29,8 @@ module.exports = MailsInput = React.createClass
         return state
 
     componentWillReceiveProps: (nextProps) ->
-        value = nextProps.valueLink.value
-        @setState known: value, focus: !!value.length
+        isFocus = _.isEmpty nextProps.valueLink.value
+        @setState known: value, focus: not isFocus
 
     # Code from the StoreWatch Mixin. We don't use the mixin
     # because we store other things into the state

--- a/client/app/components/mails_input.coffee
+++ b/client/app/components/mails_input.coffee
@@ -25,10 +25,12 @@ module.exports = MailsInput = React.createClass
         state.unknown  = ''
         state.selected = 0
         state.open     = false
+        state.focus    = !!state.known.length
         return state
 
     componentWillReceiveProps: (nextProps) ->
-        @setState known: nextProps.valueLink.value
+        value = nextProps.valueLink.value
+        @setState known: value, focus: !!value.length
 
     # Code from the StoreWatch Mixin. We don't use the mixin
     # because we store other things into the state
@@ -45,7 +47,6 @@ module.exports = MailsInput = React.createClass
             not (_.isEqual(nextProps, @props))
 
     render: ->
-
         renderTag = (address, idx) =>
             remove = =>
                 known = @state.known.filter (a) ->
@@ -128,9 +129,10 @@ module.exports = MailsInput = React.createClass
                 event.dataTransfer.dropEffect = 'none'
 
         # Show field if results
-        className += ' shown' unless (hasNoContact = _.isEmpty knownContacts)
+        className += ' shown' if @state.focus
 
         # don't display placeholder if there are dests
+        hasNoContact = _.isEmpty knownContacts
         placeholder = unless hasNoContact then '' else @props.placeholder
 
         div

--- a/client/app/components/panel.coffee
+++ b/client/app/components/panel.coffee
@@ -123,6 +123,7 @@ module.exports = Panel = React.createClass
             selectedMailboxID    : @props.selectedMailboxID
             useIntents           : @props.useIntents
             ref                  : 'compose'
+            key                  : @props.action or 'compose'
 
         component = null
 
@@ -133,7 +134,9 @@ module.exports = Panel = React.createClass
 
         # Generates the edit draft composition form.
         else if @props.action is 'edit'
-            options.message = MessageStore.getByID @props.messageID
+            messageID = @props.messageID
+            options.message = MessageStore.getByID messageID
+            options.key += '-' + messageID
             component = Compose options
 
         # Generates the reply composition form.

--- a/client/app/components/panel.coffee
+++ b/client/app/components/panel.coffee
@@ -135,9 +135,11 @@ module.exports = Panel = React.createClass
         # Generates the edit draft composition form.
         else if @props.action is 'edit'
             messageID = @props.messageID
-            options.message = MessageStore.getByID messageID
-            options.key += '-' + messageID
-            component = Compose options
+            if (message = MessageStore.getByID messageID)
+                options.key += '-' + messageID
+                component = Compose _.extend options,
+                    key: options.key + '-' + messageID
+                    message: message
 
         # Generates the reply composition form.
         else if @props.action is 'compose.reply'

--- a/client/app/constants/app_constants.coffee
+++ b/client/app/constants/app_constants.coffee
@@ -121,6 +121,7 @@ module.exports =
         'REPLY'         : 'REPLY'
         'REPLY_ALL'     : 'REPLY_ALL'
         'FORWARD'       : 'FORWARD'
+        'EDIT'          : 'EDIT'
 
     AlertLevel:
         'SUCCESS'      : 'SUCCESS'

--- a/client/app/utils/message_utils.coffee
+++ b/client/app/utils/message_utils.coffee
@@ -472,6 +472,25 @@ module.exports = MessageUtils =
 
         return text.substr 0, 1024
 
+    # set source of attached images
+    cleanHTML: (html) ->
+        parser = new DOMParser()
+        unless (doc = parser.parseFromString html, "text/html")
+            doc = document.implementation.createHTMLDocument("")
+            doc.documentElement.innerHTML = html
+            unless doc
+                console.error "Unable to parse HTML content of message"
+                return html
+
+        # the contentID of attached images will be in the data-src attribute
+        # override image source with this attribute
+        imageSrc = (image) ->
+            image.setAttribute 'src', "cid:#{image.dataset.src}"
+        images = doc.querySelectorAll 'IMG[data-src]'
+        imageSrc image for image in images
+
+        doc.documentElement.innerHTML
+
     # Remove from given string:
     # * html tags
     # * extra spaces between reply markers and text

--- a/client/app/utils/message_utils.coffee
+++ b/client/app/utils/message_utils.coffee
@@ -185,10 +185,10 @@ module.exports = MessageUtils =
             when null
                 @setMessageAsDefault options
 
-        # remove my address from dests
-        notMe = (dest) -> return dest.address isnt account.address
-        message.to = message.to.filter notMe
-        message.cc = message.cc.filter notMe
+        # # remove my address from dests
+        # notMe = (dest) -> return dest.address isnt account.address
+        # message.to = message.to.filter notMe
+        # message.cc = message.cc.filter notMe
 
         message
 

--- a/client/app/utils/message_utils.coffee
+++ b/client/app/utils/message_utils.coffee
@@ -135,6 +135,7 @@ module.exports = MessageUtils =
 
         # edition of an existing draft
         if (_message = props.message)
+            props.action = ComposeActions.EDIT unless props.action
             _.extend message, _message.toJS()
             message.attachments = _message.get 'attachments'
             delete props.message

--- a/client/app/utils/message_utils.coffee
+++ b/client/app/utils/message_utils.coffee
@@ -185,11 +185,6 @@ module.exports = MessageUtils =
             when null
                 @setMessageAsDefault options
 
-        # # remove my address from dests
-        # notMe = (dest) -> return dest.address isnt account.address
-        # message.to = message.to.filter notMe
-        # message.cc = message.cc.filter notMe
-
         message
 
 

--- a/client/app/utils/message_utils.coffee
+++ b/client/app/utils/message_utils.coffee
@@ -115,7 +115,7 @@ module.exports = MessageUtils =
     # It add appropriate headers to the message. It adds style tags when
     # required too.
     # It adds signature at the end of the zone where the user will type.
-    makeReplyMessage: (props) ->
+    createBasicMessage: (props) ->
         account = props.accounts.get props.selectedAccountID
         account =
             id: props.selectedAccountID


### PR DESCRIPTION
## Use cases

## Creating a new message
When I click on 'compose' : 
 - an empty draft is displayed

When I change the fields : to, cc, ccc, subject, message, attachment,
 - [x] message is saved on client,
 - [x] message is saved on server.
 - [x] a draft is created on 1st save,
 - [x] DO not create empty message

## Updating message in Drafts
I choose 'Draft' MailBox, and I click on a message in the list
 - [x] ComposeView is displayed with the right data

When I change the fields : to, cc, ccc, subject, message, attachment,
 - [x] message is saved on client,
 - [x] message is saved on server.
 - [x] a draft is created on 1st save,
 - [x] that draft is updated on other save

## Create message : Display ModalBox
 I save data when the component is unmounted 
 - [x] I show Modal when there are differences between client and server data
 - [x] nothing happen if I saved draft before component is unmounted

## Edit draft message : Display ModalBox
 I save data when the component is unmounted 
 - [x] I show Modal when there are differences between client and server data
 - [x] nothing happen if I saved draft before component is unmounted

When I click on a draft into the list and click on another draft :
 - [x] `subject` is updated
 - [x] `cc` is updated
 - [x] `bcc` is updated
 - [x] `content` is updated

Then I click on `cc` (field `cc` is visible) and change the draft selection :
 - [x] `cc` is hidden

Then I click on `bcc` (field `cc` is visible) and change the draft selection :
 - [x] `bcc` is hidden

## Basic message feature
 - [x] toggle between `cc`and `bcc` fields,
 - [x] attachements : add, remove, save,
 - [x] HTML text is style HTML,
 - [x] picture is still a picture