### PR TITLE
Loosing focus in message list when remove a message (Suppr)

### DIFF
--- a/client/app/components/conversation.coffee
+++ b/client/app/components/conversation.coffee
@@ -31,14 +31,14 @@ module.exports = React.createClass
         selectedMailboxID = AccountStore.getSelectedMailbox()?.get 'id'
         selectedAccount = AccountStore.getSelectedOrDefault()
 
-
         if message?
             conversationID = message?.get('conversationID')
             trashMailboxID = selectedAccount?.get('trashMailbox')
-            conversation = MessageStore
-                           .getConversation conversationID, trashMailboxID
-            prevMessage = MessageStore.getPreviousMessage(true)
-            nextMessage = MessageStore.getNextMessage(true)
+
+            conversation = MessageStore.getConversation {conversationID}
+            prevMessage = MessageStore.getPreviousConversation()
+            nextMessage = MessageStore.getNextConversation()
+
             length = MessageStore.getConversationsLength().get conversationID
             selectedMailboxID ?= Object.keys(message.get('mailboxIDs'))[0]
 

--- a/client/app/components/message.coffee
+++ b/client/app/components/message.coffee
@@ -281,17 +281,18 @@ module.exports = React.createClass
         event.stopPropagation()
 
         success = =>
-            # Get next focus message
+            # Get next focus conversation
             unless (nextConversation = MessageStore.getNextConversation()).size
                 nextConversation = MessageStore.getPreviousConversation()
 
             # Then remove message
             MessageActionCreator.delete messageID: @state.currentMessageID
 
-            # Goto to next message
             unless nextConversation.size
+                # Close 2nd panel : no next conversation found
                 @redirect (url = @buildClosePanelUrl 'second')
             else
+                # Goto to next conversation
                 @redirect
                     direction: 'second',
                     action: 'conversation',

--- a/client/app/components/message.coffee
+++ b/client/app/components/message.coffee
@@ -289,12 +289,15 @@ module.exports = React.createClass
             MessageActionCreator.delete messageID: @state.currentMessageID
 
             # Goto to next message
-            @redirect
-                direction: 'second',
-                action: 'conversation',
-                parameters:
-                    messageID: nextConversation.get('id')
-                    conversationID: nextConversation.get('conversationID')
+            unless nextConversation.size
+                @redirect (url = @buildClosePanelUrl 'second')
+            else
+                @redirect
+                    direction: 'second',
+                    action: 'conversation',
+                    parameters:
+                        messageID: nextConversation.get('id')
+                        conversationID: nextConversation.get('conversationID')
 
         needConfirmation = @props.settings.get('messageConfirmDelete')
         unless needConfirmation

--- a/client/app/components/message.coffee
+++ b/client/app/components/message.coffee
@@ -8,6 +8,8 @@ MessageFooter  = require "./message_footer"
 ToolbarMessage = require './toolbar_message'
 MessageContent = require './message-content'
 
+MessageStore = require '../stores/message_store'
+
 {MessageFlags} = require '../constants/app_constants'
 
 LayoutActionCreator       = require '../actions/layout_action_creator'
@@ -279,11 +281,20 @@ module.exports = React.createClass
         event.stopPropagation()
 
         success = =>
-            messageID = @props.message.get('id')
-            MessageActionCreator.delete {messageID}
+            # Get next focus message
+            unless (nextConversation = MessageStore.getNextConversation()).size
+                nextConversation = MessageStore.getPreviousConversation()
 
-             # Close Detail Panel for deleted message
-            @redirect (url = @buildClosePanelUrl 'second')
+            # Then remove message
+            MessageActionCreator.delete messageID: @state.currentMessageID
+
+            # Goto to next message
+            @redirect
+                direction: 'second',
+                action: 'conversation',
+                parameters:
+                    messageID: nextConversation.get('id')
+                    conversationID: nextConversation.get('conversationID')
 
         needConfirmation = @props.settings.get('messageConfirmDelete')
         unless needConfirmation

--- a/client/app/components/toolbar_conversation.coffee
+++ b/client/app/components/toolbar_conversation.coffee
@@ -42,13 +42,13 @@ module.exports = React.createClass
 
                 LinkButton
                     icon: if @props.prevMessageID then 'fa-chevron-left'
-                    onClick: @onPrevClicked
+                    onClick: @gotoPreviousConversation
                     'aria-describedby': Tooltips.PREVIOUS_CONVERSATION
                     'data-tooltip-direction': 'left'
 
                 LinkButton
                     icon: if @props.nextMessageID then 'fa-chevron-right'
-                    onClick: @onNextClicked
+                    onClick: @gotoNextConversation
                     'aria-describedby': Tooltips.NEXT_CONVERSATION
                     'data-tooltip-direction': 'left'
 
@@ -58,28 +58,34 @@ module.exports = React.createClass
                 onClick: LayoutActionCreator.toggleFullscreen
                 className: "clickable fullscreen"
 
-    onPrevClicked: ->
-        return null unless @props.prevMessageID
-        @redirect
-            direction: 'second',
-            action: 'conversation',
-            parameters:
-                messageID: @props.prevMessageID
-                conversationID: @props.prevConversationID
+    gotoPreviousConversation: ->
+        messageID = @props.prevMessageID
+        conversationID = @props.prevConversationID
+        if not messageID or not conversationID
+            @redirect (url = @buildClosePanelUrl 'second')
+            return
 
-    onNextClicked: ->
-        return null unless @props.nextMessageID
-        @redirect
-            direction: 'second',
-            action: 'conversation',
-            parameters:
-                messageID: @props.nextMessageID
-                conversationID: @props.nextConversationID
+        parameters = @getUrlParams messageID, conversationID
+        @redirect parameters
+        return
+
+    gotoNextConversation: ->
+        messageID = @props.nextMessageID
+        conversationID = @props.nextConversationID
+        if not messageID or not conversationID
+            @gotoPreviousConversation()
+            return
+
+        parameters = @getUrlParams messageID, conversationID
+        @redirect parameters
+        return
 
     onDelete: ->
+        # Remove conversation
         conversationID = @props.conversationID
         MessageActionCreator.delete {conversationID}
-        @redirect (url = @buildClosePanelUrl 'second')
+
+        @gotoNextConversation()
 
     onMark: (flag) ->
         conversationID = @props.conversationID
@@ -93,6 +99,6 @@ module.exports = React.createClass
     getUrlParams: (messageID, conversationID) ->
         direction: 'second'
         action: 'conversation'
-        parameters: parameters
+        parameters:
             messageID: messageID
             conversationID: conversationID

--- a/client/app/stores/message_store.coffee
+++ b/client/app/stores/message_store.coffee
@@ -258,8 +258,6 @@ class MessageStore extends Store
 
         handle ActionTypes.MESSAGE_TRASH_REQUEST, ({target, ref}) ->
             messages = _getMixed target
-            # FIXME : voir pkoi si on retire ces deux lignes
-            # ça crée une erreur 400
             target.subject = messages[0]?.get('subject')
             target.accountID = messages[0].get('accountID')
             account = AccountStore.getByID messages[0]?.get('accountID')

--- a/client/app/stores/message_store.coffee
+++ b/client/app/stores/message_store.coffee
@@ -510,9 +510,23 @@ class MessageStore extends Store
     getCurrentConversationID: ->
         return _currentCID
 
+    ###*
+    * Get older conversation displayed before current
+    *
+    * @param {Function}  transform
+    *
+    * @return {List}
+    ###
     getPreviousConversation: (param={}) ->
         @getConversation transform: (index) -> ++index
 
+    ###*
+    * Get earlier conversation displayed after current
+    *
+    * @param {Function}  transform
+    *
+    * @return {List}
+    ###
     getNextConversation: (param={}) ->
         @getConversation transform: (index) -> --index
 
@@ -530,6 +544,19 @@ class MessageStore extends Store
                 message.get('conversationID') is conversationID
             .sort reverseDateSort
 
+    ###*
+    * Get Conversation
+    *
+    * If none parameters    return current conversation
+    * @param.transform      return the list index needed
+    * @param.type="message" return the closest message
+    *                       instead of conversation
+    *
+    * @param {String}   type
+    * @param {Function} transform
+    *
+    * @return {List}
+    ###
     getConversation: (param={}) ->
         @setConversation param.conversationID if param.conversationID?
         return _conversationMemoize unless _.isFunction param.transform

--- a/client/app/stores/message_store.coffee
+++ b/client/app/stores/message_store.coffee
@@ -257,9 +257,7 @@ class MessageStore extends Store
             @emit 'change'
 
         handle ActionTypes.MESSAGE_TRASH_REQUEST, ({target, ref}) ->
-            messages = _getMixed target
-            target.subject = messages[0]?.get('subject')
-            target.accountID = messages[0].get('accountID')
+            messages = @getMixed target
             account = AccountStore.getByID messages[0]?.get('accountID')
             trashBoxID = account?.get? 'trashMailbox'
             _addInFlight {type: 'trash', trashBoxID, messages, ref}
@@ -285,7 +283,7 @@ class MessageStore extends Store
 
         handle ActionTypes.MESSAGE_TRASH_FAILURE, ({target, ref}) ->
             _removeInFlight ref
-            messages = _getMixed target
+            messages = @getMixed target
             for message in messages
                 # Update conversation length
                 conversationID = message.get('conversationID')
@@ -295,9 +293,7 @@ class MessageStore extends Store
             @emit 'change'
 
         handle ActionTypes.MESSAGE_FLAGS_REQUEST, ({target, op, flag, ref}) ->
-            messages = _getMixed target
-            target.subject = messages[0]?.get('subject')
-            target.accountID = messages[0].get('accountID')
+            messages = @getMixed target
             _addInFlight {type: 'flag', op, flag, messages, ref}
             @emit 'change'
 
@@ -311,9 +307,7 @@ class MessageStore extends Store
             @emit 'change'
 
         handle ActionTypes.MESSAGE_MOVE_REQUEST, ({target, from, to, ref}) ->
-            messages = _getMixed target
-            target.subject = messages[0]?.get('subject')
-            target.accountID = messages[0].get('accountID')
+            messages = @getMixed target
             _addInFlight {type: 'move', from, to, messages, ref}
             @emit 'change'
 
@@ -562,10 +556,13 @@ class MessageStore extends Store
     # Retrieve a batch of message with various criteria
     # target - is an {Object} with a property messageID or messageIDs or
     #          conversationID or conversationIDs
+    # target.accountID is needed to success Delete
     #
     # Returns an {Array} of {Immutable.Map} messages
     getMixed: (target) ->
-        _getMixed target
+        messages = _getMixed target
+        target.accountID = messages[0].get('accountID')
+        messages
 
     getConversationsLength: ->
         return _conversationLengths

--- a/client/app/utils/api_utils.coffee
+++ b/client/app/utils/api_utils.coffee
@@ -40,9 +40,7 @@ module.exports =
 
 
     getCurrentConversation: ->
-        conversationID = MessageStore.getCurrentConversationID()
-        if conversationID?
-            return MessageStore.getConversation(conversationID)?.toJS()
+        MessageStore.getCurrentConversation()?.toJS()
 
 
     getCurrentActions: ->
@@ -95,21 +93,21 @@ module.exports =
             value: settings
 
     messageNavigate: (direction, inConv) ->
-        if not onMessageList()
-            return
+        return unless onMessageList()
         conv = inConv and SettingsStore.get('displayConversation') and
             SettingsStore.get('displayPreview')
-        if direction is 'prev'
-            next = MessageStore.getPreviousMessage conv
-        else
-            next = MessageStore.getNextMessage conv
-        if not next?
-            return
 
-        @messageSetCurrent next
+        if direction is 'prev'
+            next = MessageStore.getNextConversation()
+        else
+            next = MessageStore.getPreviousConversation()
+
+        @messageSetCurrent(next)
 
 
     messageSetCurrent: (message) ->
+        return unless message?.get('id')
+
         MessageActionCreator.setCurrent message.get('id'), true
 
         if SettingsStore.get('displayPreview')

--- a/client/app/utils/api_utils.coffee
+++ b/client/app/utils/api_utils.coffee
@@ -97,6 +97,9 @@ module.exports =
         conv = inConv and SettingsStore.get('displayConversation') and
             SettingsStore.get('displayPreview')
 
+        # The most recent conversation are on top of the list
+        # and older are below
+        # that why order is reversed
         if direction is 'prev'
             next = MessageStore.getNextConversation()
         else

--- a/client/app/utils/api_utils.coffee
+++ b/client/app/utils/api_utils.coffee
@@ -94,12 +94,14 @@ module.exports =
 
     messageNavigate: (direction, inConv) ->
         return unless onMessageList()
+        console.log 'messageNavigate', direction
+
         conv = inConv and SettingsStore.get('displayConversation') and
             SettingsStore.get('displayPreview')
 
-        # The most recent conversation are on top of the list
-        # and older are below
-        # that why order is reversed
+        # when key top is pressed, direction=prev
+        # when key bottom is pressed, direction=next
+        # strange (?!)
         if direction is 'prev'
             next = MessageStore.getNextConversation()
         else


### PR DESCRIPTION
Actually `_fixCurrentMessage ` should do that stuff but it doesnt work.

When a message is deleted : 
 - [x] next message in the list should be focus,
 - [x] URL should be updated.

When a user navigate with keyboard into messageList : 
 - [x] next message should be focus when I press on `top` key,
 - [x] previous message should be focus when I press on `bottom` key.
