### PR TITLE
New messages are not visible enought

### DIFF
--- a/client/app/components/basic_components.coffee
+++ b/client/app/components/basic_components.coffee
@@ -331,6 +331,7 @@ Icon = React.createClass
         type: React.PropTypes.string.isRequired
 
     render: ->
+
         className = "#{@props.className or ''} fa fa-#{@props.type}"
         i
             className: className

--- a/client/app/components/message-list-item.coffee
+++ b/client/app/components/message-list-item.coffee
@@ -1,11 +1,11 @@
 {div, section, p, ul, li, a, span, i, button, input, img} = React.DOM
 {MessageFlags, MailboxFlags} = require '../constants/app_constants'
-{Icon} = require './basic_components'
-RouterMixin           = require '../mixins/router_mixin'
-classer      = React.addons.classSet
-MessageUtils = require '../utils/message_utils'
-colorhash    = require '../utils/colorhash'
-Participants        = require './participant'
+{Icon}               = require './basic_components'
+RouterMixin          = require '../mixins/router_mixin'
+classer              = React.addons.classSet
+MessageUtils         = require '../utils/message_utils'
+colorhash            = require '../utils/colorhash'
+Participants         = require './participant'
 MessageActionCreator = require '../actions/message_action_creator'
 
 
@@ -62,16 +62,19 @@ module.exports = MessageItem = React.createClass
 
                 div className: 'markers-wrapper',
                     Icon
+                        type: 'new-icon'
+                        className: 'hidden' if MessageFlags.SEEN in flags
+
+                    Icon
                         className: 'select'
                         onClick:   @onSelect
                         type: (if @props.selected then 'check-square-o'
                         else 'square-o')
 
-                    if MessageFlags.SEEN not in flags
-                        Icon type: 'circle'
+                    Icon
+                        type: 'star'
+                        className: 'hidden' if MessageFlags.FLAGGED not in flags
 
-                    if MessageFlags.FLAGGED in flags
-                        Icon type: 'star'
 
                 div className: 'avatar-wrapper select-target',
                     if avatar?

--- a/client/app/styles/_message-list.styl
+++ b/client/app/styles/_message-list.styl
@@ -175,7 +175,7 @@
         table-layout     fixed
         width            100%
         padding          .5em .4em 1em
-        background-color lighten(lightcolor,90%)
+        background-color lighten(lightcolor,60%)
         border-bottom    1px solid grey-02
 
         main:not(.full) &.active
@@ -195,8 +195,9 @@
     .unseen
         background-color white
 
-        .subject
-            font-weight bold
+        .participants
+            .address-list
+                font-weight bold
 
 
     .wrapper
@@ -253,9 +254,6 @@
         justify-content space-between
 
 
-    .participants
-        font-weight bold
-
     .subject
         font-size (15/16)em
 
@@ -263,16 +261,14 @@
         color     grey-06
         font-size .875em
 
-    .mailboxes
-        font-size .875em
-
-        span
-            display          inline-block
-            margin-right     .5em
-            background-color rgba(grey-02, .67)
-            border-radius    .1em
-            padding          .1em .35em
-            color            darkcolor
+    .mailbox-tag
+        font-size        .8em
+        display          inline-block
+        margin-right     .5em
+        background-color rgba(grey-02, .67)
+        border-radius    .1em
+        padding          .1em .35em
+        color            darkcolor
 
 
     .date

--- a/client/app/styles/_message-list.styl
+++ b/client/app/styles/_message-list.styl
@@ -54,10 +54,7 @@
     [role=toolbar]
         display    flex
         min-height (36/16)em
-
-
-    [role=toolbar]
-        padding          .1875em .35em (1/16)em
+        padding          .1875em .7em (1/16)em
         background-color grey-01
         font-size        .90em
 
@@ -74,6 +71,9 @@
         .dropdown
         .menu-action
             display flex
+
+        [role=group]
+            margin-left 2em
 
         .dropdown-toggle
             white-space nowrap
@@ -170,11 +170,12 @@
 
 
     .message
+        position relative
         display          table
         table-layout     fixed
         width            100%
-        padding          .5em .35em
-        background-color lighten(grey-01, 66%)
+        padding          .5em .4em 1em
+        background-color lighten(lightcolor,90%)
         border-bottom    1px solid grey-02
 
         main:not(.full) &.active
@@ -184,6 +185,12 @@
             .preview
                 color darkcolor
 
+        .fa-new-icon
+            position absolute
+            border-left solid 0.25em blue
+            height 100%
+            top 0
+            left 0
 
     .unseen
         background-color white
@@ -199,20 +206,24 @@
 
         [class*=wrapper]
             display        table-cell
-            vertical-align middle
-            padding        0 .5em
+            vertical-align top
 
         p
             margin 0
 
 
     .markers-wrapper
-        marker-width = .85em
+        marker-width = 1em
 
-        width 1em + marker-width
+        width 2em + marker-width
+        padding 1em 0.3em 0
 
         i
             font-size marker-width
+            padding 0 0 0 0.3em
+
+        .hidden
+            display: inline-block!important
 
         .fa-circle
             color basecolor
@@ -300,17 +311,12 @@
     .message
         .select
             cursor  pointer
-            display none
 
+        .fa-square-o
+            color grey-03
 
-        &:hover
-        &.edited
-            .markers-wrapper
-                .select
-                    display block
-                i
-                    display none
-
+        .fa-check-square-o
+            color grey-07
 
 
     // LAYOUT SPECIFIC RULES
@@ -318,7 +324,6 @@
     .layout-column &
         .avatar-wrapper
             width 3.5em
-            padding 0 .25em
 
         .avatar
             width  2em
@@ -327,12 +332,6 @@
         .participants
         .subject
             flex 1 0 50%
-
-        .participants
-        .subject
-        .mailboxes
-        .preview
-            margin .125em 0
 
         .mailboxes
         .preview
@@ -378,9 +377,6 @@
     .layout-row &
         .metas-wrapper
             flex-wrap nowrap
-
-        .message
-            padding 0.25em 0.35em
 
         .metas
             flex-wrap nowrap

--- a/client/app/styles/_message-list.styl
+++ b/client/app/styles/_message-list.styl
@@ -174,7 +174,7 @@
         display          table
         table-layout     fixed
         width            100%
-        padding          .5em .4em 1em
+        padding          .5em .4em .75em
         background-color lighten(lightcolor,60%)
         border-bottom    1px solid grey-02
 
@@ -207,7 +207,7 @@
 
         [class*=wrapper]
             display        table-cell
-            vertical-align top
+            vertical-align middle
 
         p
             margin 0
@@ -217,7 +217,7 @@
         marker-width = 1em
 
         width 2em + marker-width
-        padding 1em 0.3em 0
+        padding 0em 0.3em 0
 
         i
             font-size marker-width


### PR DESCRIPTION
## Changes

 - Create 3 columns for message state : `new` icon, checkbox and favorite,
 - align filter toolbox with columns,
 - change `new-icon` into a blue rectangle,
 - add bigger vertical space between messages,
 - compress message item (remove vertical padding),
 - set subject to normal weight (remove bold).
 - [ ] add icon favorite-off

### Rows view
<img width="1434" alt="new-row" src="https://cloud.githubusercontent.com/assets/1177627/13463076/d845f2f6-e08a-11e5-8540-636298fbd7b2.png">
<img width="1436" alt="new-row-fav" src="https://cloud.githubusercontent.com/assets/1177627/13463116/0bd1a48a-e08b-11e5-8ccf-21024738f9b3.png">



### Columns view
<img width="1436" alt="layout-columns" src="https://cloud.githubusercontent.com/assets/1177627/13463085/e40ea484-e08a-11e5-90c2-116ff77bbebf.png">
<img width="1434" alt="layout-columns-fav" src="https://cloud.githubusercontent.com/assets/1177627/13463084/e40d30ea-e08a-11e5-8e37-2eacccad4b4b.png">


## Current version
<img width="1430" alt="new-messages old" src="https://cloud.githubusercontent.com/assets/1177627/13433259/57901f4c-dfd1-11e5-94c4-a68a74ecf7f6.png">