### PR TITLE
Fix focus next message after destroy

### DIFF
--- a/client/app/components/message.coffee
+++ b/client/app/components/message.coffee
@@ -282,8 +282,7 @@ module.exports = React.createClass
 
         success = =>
             # Get next focus conversation
-            unless (nextConversation = MessageStore.getNextConversation()).size
-                nextConversation = MessageStore.getPreviousConversation()
+            nextConversation = MessageStore.getPreviousConversation()
 
             # Then remove message
             MessageActionCreator.delete messageID: @state.currentMessageID

--- a/client/app/components/message.coffee
+++ b/client/app/components/message.coffee
@@ -283,6 +283,7 @@ module.exports = React.createClass
         success = =>
             # Get next focus conversation
             nextConversation = MessageStore.getPreviousConversation()
+            nextConversation = MessageStore.getNextConversation() unless nextConversation.size
 
             # Then remove message
             MessageActionCreator.delete messageID: @state.currentMessageID

--- a/client/app/components/toolbar_conversation.coffee
+++ b/client/app/components/toolbar_conversation.coffee
@@ -80,7 +80,7 @@ module.exports = React.createClass
 
     goto: (messageID, conversationID) ->
         if not messageID or not conversationID
-            @redirect (url = @buildClosePanelUrl 'second')
+            @redirect @buildClosePanelUrl 'second'
             return
 
         parameters = @getUrlParams messageID, conversationID

--- a/client/app/components/toolbar_conversation.coffee
+++ b/client/app/components/toolbar_conversation.coffee
@@ -83,9 +83,11 @@ module.exports = React.createClass
     onDelete: ->
         # Remove conversation
         conversationID = @props.conversationID
+
         MessageActionCreator.delete {conversationID}
 
-        @gotoNextConversation()
+        # Select previous conversation
+        @gotoPreviousConversation()
 
     onMark: (flag) ->
         conversationID = @props.conversationID

--- a/client/app/components/toolbar_conversation.coffee
+++ b/client/app/components/toolbar_conversation.coffee
@@ -59,26 +59,32 @@ module.exports = React.createClass
                 className: "clickable fullscreen"
 
     gotoPreviousConversation: ->
-        messageID = @props.prevMessageID
-        conversationID = @props.prevConversationID
+        if (messageID = @props.prevMessageID)
+            conversationID = @props.prevConversationID
+        else
+            # Current Message is the last of the list
+            messageID = @props.nextMessageID
+            conversationID = @props.nextConversationID
+        @goto messageID, conversationID
+        return
+
+    gotoNextConversation: ->
+        if (messageID = @props.nextMessageID)
+            conversationID = @props.nextConversationID
+        else
+            # Current Message is the first of the list
+            messageID = @props.prevMessageID
+            conversationID = @props.prevConversationID
+        @goto messageID, conversationID
+        return
+
+    goto: (messageID, conversationID) ->
         if not messageID or not conversationID
             @redirect (url = @buildClosePanelUrl 'second')
             return
 
         parameters = @getUrlParams messageID, conversationID
         @redirect parameters
-        return
-
-    gotoNextConversation: ->
-        messageID = @props.nextMessageID
-        conversationID = @props.nextConversationID
-        if not messageID or not conversationID
-            @gotoPreviousConversation()
-            return
-
-        parameters = @getUrlParams messageID, conversationID
-        @redirect parameters
-        return
 
     onDelete: ->
         # Remove conversation

--- a/client/app/components/toolbar_messageslist_actions.coffee
+++ b/client/app/components/toolbar_messageslist_actions.coffee
@@ -96,7 +96,7 @@ module.exports = ActionsToolbarMessagesList = React.createClass
 
             unless nextConversation.size
                 # Close 2nd panel : no next conversation found
-                @redirect (url = @buildClosePanelUrl 'second')
+                @redirect @buildClosePanelUrl 'second'
             else
                 # Goto to next conversation
                 @redirect

--- a/client/app/components/toolbar_messageslist_actions.coffee
+++ b/client/app/components/toolbar_messageslist_actions.coffee
@@ -4,6 +4,8 @@
 ToolboxActions = require './toolbox_actions'
 ToolboxMove    = require './toolbox_move'
 
+MessageStore = require '../stores/message_store'
+
 LayoutActionCreator  = require '../actions/layout_action_creator'
 MessageActionCreator = require '../actions/message_action_creator'
 
@@ -84,15 +86,26 @@ module.exports = ActionsToolbarMessagesList = React.createClass
         return unless options = @_getSelectedAndMode applyToConversation
 
         doDelete = =>
-            MessageActionCreator.delete options, =>
-                if options.count > 0 and @props.messages.size > 0
-                    firstMessageID = @props.messages.first().get('id')
-                    MessageActionCreator.setCurrent firstMessageID, true
+            # Get next focus conversation
+            nextConversation = MessageStore.getPreviousConversation()
+            nextConversation = MessageStore.getNextConversation() unless nextConversation.size
+
+            MessageActionCreator.delete options
 
             @props.afterAction() if @props.afterAction?
 
-            # Close Detail Panel for deleted message
-            @redirect (url = @buildClosePanelUrl 'second')
+            unless nextConversation.size
+                # Close 2nd panel : no next conversation found
+                @redirect (url = @buildClosePanelUrl 'second')
+            else
+                # Goto to next conversation
+                @redirect
+                    direction: 'second',
+                    action: 'conversation',
+                    parameters:
+                        messageID: nextConversation.get('id')
+                        conversationID: nextConversation.get('conversationID')
+
 
         unless @props.settings.get 'messageConfirmDelete'
             doDelete()

--- a/client/app/utils/api_utils.coffee
+++ b/client/app/utils/api_utils.coffee
@@ -165,6 +165,7 @@ module.exports = Utils =
             # Get next message information
             # before delete (context changes)
             next = MessageStore.getPreviousConversation()
+            next = MessageStore.getNextConversation() unless next.size
 
             MessageActionCreator.delete {messageID}
             LayoutActionCreator.hideModal() if isModal

--- a/client/app/utils/api_utils.coffee
+++ b/client/app/utils/api_utils.coffee
@@ -162,9 +162,15 @@ module.exports = Utils =
             return
 
         deleteMessage = (isModal) ->
+            # Get next message information
+            # before delete (context changes)
+            next = MessageStore.getPreviousConversation()
+
             MessageActionCreator.delete {messageID}
             LayoutActionCreator.hideModal() if isModal
-            Utils.messageClose()
+
+            # Goto next message
+            Utils.messageSetCurrent next
 
         settings = SettingsStore.get()
 


### PR DESCRIPTION
When message is deleted with 'suppr' key or 'trash' ico in messages list toolbar, focus is lost.

See these PR for history :
Delete Email causes suppression of 2nd panel
https://github.com/cozy/cozy-emails/pull/744
https://github.com/cozy/cozy-emails/pull/753
https://github.com/cozy/cozy-emails/pull/762
https://github.com/cozy/cozy-emails/pull/767

Keep focus on MessageList
https://github.com/cozy/cozy-emails/pull/759