### PR TITLE
Fix focus next message after destroy (part 2)

### DIFF
--- a/client/app/actions/message_action_creator.coffee
+++ b/client/app/actions/message_action_creator.coffee
@@ -163,7 +163,7 @@ module.exports = MessageActionCreator =
                 # in doubt, recover the changed to messages to sync with
                 # server
                 @recover target, ref
-            else
+            else if updated?.length
                 msg.updated = ts for msg in updated
                 AppDispatcher.handleViewAction
                     type: ActionTypes.MESSAGE_TRASH_SUCCESS

--- a/client/app/components/conversation.coffee
+++ b/client/app/components/conversation.coffee
@@ -123,14 +123,14 @@ module.exports = React.createClass
 
 
     render: ->
-        unless @state.conversation
+        if not @state.conversation or not (message = @state.conversation.get 0)
             return section
                 key: 'conversation'
                 className: 'conversation panel'
                 'aria-expanded': true,
                 p null, t "app loading"
 
-        message = @state.conversation.get 0
+
         # Sort messages in conversation to find seen messages and group them
         messages = []
         lastMessageIndex = @state.conversation.size - 1

--- a/client/app/components/toolbar_messageslist_actions.coffee
+++ b/client/app/components/toolbar_messageslist_actions.coffee
@@ -87,8 +87,9 @@ module.exports = ActionsToolbarMessagesList = React.createClass
 
         doDelete = =>
             # Get next focus conversation
-            nextConversation = MessageStore.getPreviousConversation()
-            nextConversation = MessageStore.getNextConversation() unless nextConversation.size
+            conversationIDs = options.conversationIDs
+            nextConversation = MessageStore.getPreviousConversation {conversationIDs}
+            nextConversation = MessageStore.getNextConversation {conversationIDs} unless nextConversation.size
 
             MessageActionCreator.delete options
 
@@ -105,7 +106,6 @@ module.exports = ActionsToolbarMessagesList = React.createClass
                     parameters:
                         messageID: nextConversation.get('id')
                         conversationID: nextConversation.get('conversationID')
-
 
         unless @props.settings.get 'messageConfirmDelete'
             doDelete()

--- a/client/app/stores/message_store.coffee
+++ b/client/app/stores/message_store.coffee
@@ -590,9 +590,6 @@ class MessageStore extends Store
         messageID = param.messageID or @getCurrentID()
         conversationID = param.conversationID
 
-        # FIXME : FIX de la Inbox :
-        # lorsque l'on change de vues
-        # la sélection doit être supprimée
         messages = _messagesWithInFlights()
 
         # Remove selected messages

--- a/client/app/utils/api_utils.coffee
+++ b/client/app/utils/api_utils.coffee
@@ -145,6 +145,7 @@ module.exports = Utils =
             direction: 'second'
             action: action
             parameters: params
+
         url = window.router.buildUrl urlOptions
         window.router.navigate url, {trigger: true}
 
@@ -153,8 +154,8 @@ module.exports = Utils =
         href = window.location.href
         href = href.replace /\/message\/[\w-]+/gi, ''
         href = href.replace /\/conversation\/[\w-]+\/[\w-]+/gi, ''
+        href = href.replace /\/edit\/[\w-]+/gi, ''
         window.location.href = href
-
 
     messageDeleteCurrent: ->
         messageID = MessageStore.getCurrentID()
@@ -170,8 +171,12 @@ module.exports = Utils =
             MessageActionCreator.delete {messageID}
             LayoutActionCreator.hideModal() if isModal
 
-            # Goto next message
-            Utils.messageSetCurrent next
+            if next?.size
+                # Goto next message
+                Utils.messageSetCurrent next
+            else
+                # Close 2nd panel
+                Utils.messageClose()
 
         settings = SettingsStore.get()
 


### PR DESCRIPTION
Fix special cases : 
 - navigate on messageList with keyboard works for the default list (inbox)
 - but context is lost (not well updated) when changing mail box (gap between stores & routing)

This PR try to fix the most blocking bug, but there are still some issue with deleting draft with keyboard (URL routing)

https://github.com/cozy/cozy-emails/pull/773