### PR TITLE
Reload composeView when MessageStore fetch success

### DIFF
--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -7,7 +7,6 @@ ComposeEditor  = require './compose_editor'
 ComposeToolbox = require './compose_toolbox'
 FilePicker     = require './file_picker'
 MailsInput     = require './mails_input'
-
 AccountPicker = require './account_picker'
 
 AccountStore = require '../stores/account_store'
@@ -51,22 +50,20 @@ module.exports = Compose = React.createClass
 
     getDefaultProps: ->
         layout: 'full'
-        prefixKey: 'new'
 
     getInitialState: ->
-        state = MessageUtils.createBasicMessage @props
+        @getStateFromStores()
 
-        # TODO : prefixKey should be replaced by state.id
-        # when new message would have a default id
-        @props.prefixKey = state.id if state.id
-
-        state
+    getStateFromStores: ->
+        props = _.clone @props
+        props.message = MessageStore.getByID props.messageID
+        MessageUtils.createBasicMessage props
 
     isNew: ->
         not @state.conversationID
 
     getChildKey: (name) ->
-        name + '-' + @props.prefixKey
+        'message-' + (@state.id or 'new') + '-' + name
 
     shouldComponentUpdate: (nextProps, nextState) ->
         not _.isEqual nextState, @state
@@ -78,7 +75,26 @@ module.exports = Compose = React.createClass
                 nextState.text = MessageUtils.cleanReplyText nextState.html
                 nextState.html = MessageUtils.wrapReplyHtml nextState.html
 
+    # Update state with store values.
+    _setStateFromStores: ->
+        return unless @isMounted()
+
+        _difference = (obj0, obj1) ->
+            result = {}
+            _.filter obj0, (value, key) ->
+                unless value is obj1[key]
+                    result[key] = value
+            result
+
+        nextState = @getStateFromStores()
+        changes = _difference nextState, @state
+        unless _.isEmpty changes
+            @setState nextState
+
     componentDidMount: ->
+        # Listen to Stores changes
+        MessageStore.addListener 'fetch:success', @_setStateFromStores
+
         # scroll compose window into view
         @getDOMNode().scrollIntoView()
 
@@ -110,6 +126,8 @@ module.exports = Compose = React.createClass
         delete @props.lastUpdate
 
     componentWillUnmount: ->
+        MessageStore.removeListener 'fetch:success', @_setStateFromStores
+
         # Stop listening to focus
         @removeFocusListener()
 

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -442,6 +442,7 @@ module.exports = Compose = React.createClass
                 success(error, message) if _.isFunction success
                 return
 
+            @state.mailboxIDs = message.mailboxIDs
             @props.lastUpdate = message.date
 
             # Refresh URL

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -76,8 +76,9 @@ module.exports = Compose = React.createClass
                 nextState.html = MessageUtils.wrapReplyHtml nextState.html
 
     # Update state with store values.
-    _setStateFromStores: ->
-        return unless @isMounted()
+    _setStateFromStores: (message) ->
+        if not @isMounted() or message._id isnt @state.id
+            return
 
         _difference = (obj0, obj1) ->
             result = {}

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -77,7 +77,7 @@ module.exports = Compose = React.createClass
 
     # Update state with store values.
     _setStateFromStores: (message) ->
-        if not @isMounted() or message._id isnt @state.id
+        if not @isMounted() or message?._id isnt @state.id
             return
 
         _difference = (obj0, obj1) ->
@@ -94,7 +94,7 @@ module.exports = Compose = React.createClass
 
     componentDidMount: ->
         # Listen to Stores changes
-        MessageStore.addListener 'fetch:success', @_setStateFromStores
+        MessageStore.addListener 'change', @_setStateFromStores
 
         # scroll compose window into view
         @getDOMNode().scrollIntoView()
@@ -127,14 +127,14 @@ module.exports = Compose = React.createClass
         delete @props.lastUpdate
 
     componentWillUnmount: ->
-        MessageStore.removeListener 'fetch:success', @_setStateFromStores
+        MessageStore.removeListener 'change', @_setStateFromStores
 
         # Stop listening to focus
         @removeFocusListener()
 
         # Save Message into Draft
         @closeSaveDraft @state,
-            hasChanged: @hasChanged(@props, @state)
+            hasChanged: @hasChanged(@props,  @state)
             silent: true
 
     handleFocus: ->

--- a/client/app/components/panel.coffee
+++ b/client/app/components/panel.coffee
@@ -73,7 +73,6 @@ module.exports = Panel = React.createClass
                 @props.action is 'compose.reply' or
                 @props.action is 'compose.reply-all' or
                 @props.action is 'compose.forward'
-
             @renderCompose()
 
         # -- Display the settings form
@@ -131,15 +130,14 @@ module.exports = Panel = React.createClass
             message = null
             component = Compose options
 
+
         # Generates the edit draft composition form.
         else if @props.action is 'edit' or
                 @props.action is 'compose.edit'
-            messageID = @props.messageID
-            if (message = MessageStore.getByID messageID)
-                options.key += '-' + messageID
-                component = Compose _.extend options,
-                    key: options.key + '-' + messageID
-                    message: message
+
+            component = Compose _.extend options,
+                key: options.key + '-' + @props.messageID
+                messageID: @props.messageID
 
         # Generates the reply composition form.
         else if @props.action is 'compose.reply'

--- a/client/app/stores/message_store.coffee
+++ b/client/app/stores/message_store.coffee
@@ -284,7 +284,7 @@ class MessageStore extends Store
 
         handle ActionTypes.RECEIVE_RAW_MESSAGE, (message) ->
             onReceiveRawMessage message
-            @emit 'fetch:success', message
+            @emit 'change', message
 
         handle ActionTypes.RECEIVE_RAW_MESSAGE_REALTIME, (message) ->
             onReceiveRawMessage message

--- a/client/app/stores/message_store.coffee
+++ b/client/app/stores/message_store.coffee
@@ -284,7 +284,7 @@ class MessageStore extends Store
 
         handle ActionTypes.RECEIVE_RAW_MESSAGE, (message) ->
             onReceiveRawMessage message
-            @emit 'change'
+            @emit 'fetch:success'
 
         handle ActionTypes.RECEIVE_RAW_MESSAGE_REALTIME, (message) ->
             onReceiveRawMessage message
@@ -589,7 +589,6 @@ class MessageStore extends Store
 
         messageID = param.messageID or @getCurrentID()
         conversationID = param.conversationID
-
         messages = _messagesWithInFlights()
 
         # Remove selected messages

--- a/client/app/stores/message_store.coffee
+++ b/client/app/stores/message_store.coffee
@@ -284,7 +284,7 @@ class MessageStore extends Store
 
         handle ActionTypes.RECEIVE_RAW_MESSAGE, (message) ->
             onReceiveRawMessage message
-            @emit 'fetch:success'
+            @emit 'fetch:success', message
 
         handle ActionTypes.RECEIVE_RAW_MESSAGE_REALTIME, (message) ->
             onReceiveRawMessage message

--- a/client/app/utils/message_utils.coffee
+++ b/client/app/utils/message_utils.coffee
@@ -124,6 +124,7 @@ module.exports = MessageUtils =
             signature: account.get 'signature'
 
         message =
+            id              : props.messageID
             composeInHTML   : props.settings.get 'composeInHTML'
             attachments     : Immutable.List()
             accountID       : account.id


### PR DESCRIPTION
Due to uniq `view.key` `compose` view is not as reload as before.
 - [x] Reload view when `MessageStore` changes

Regression : 
- [x] create juste one draft for a single message