### PR TITLE
Fix bare newlines warning

### DIFF
--- a/server/controllers/messages.coffee
+++ b/server/controllers/messages.coffee
@@ -193,6 +193,9 @@ module.exports.send = (req, res, next) ->
     isDraft = req.body.isDraft
     delete req.body.isDraft
 
+    message = req.body
+    message.html = message.html.trim() if message.composeInHTML
+
     proc = new SaveOrSendMessage
         account: ramStore.getAccount req.body.accountID
         previousState: req.message # can be null


### PR DESCRIPTION
Related to #695: tries to fix the error by trimming the message content of its useless bare newlines characters.