### PR TITLE
Clean Account creation views, actions, stores

### DIFF
--- a/client/app/actions/account_action_creator.coffee
+++ b/client/app/actions/account_action_creator.coffee
@@ -7,12 +7,12 @@ RouterStore = require '../stores/router_store'
 
 module.exports = AccountActionCreator =
 
-    create: (inputValues, afterCreation) ->
+    create: (value) ->
         AppDispatcher.dispatch
             type: ActionTypes.ADD_ACCOUNT_REQUEST
-            value: {inputValues}
+            value: {value}
 
-        XHRUtils.createAccount inputValues, (error, account) ->
+        XHRUtils.createAccount value, (error, account) ->
             if error?
                 AppDispatcher.dispatch
                     type: ActionTypes.ADD_ACCOUNT_FAILURE
@@ -34,12 +34,12 @@ module.exports = AccountActionCreator =
                     type: ActionTypes.ADD_ACCOUNT_SUCCESS
                     value: {account, areMailboxesConfigured}
 
-    edit: (inputValues, accountID) ->
-        newAccount = AccountStore.getByID(accountID).mergeDeep inputValues
+    edit: ({value, accountID}) ->
+        newAccount = AccountStore.getByID(accountID).mergeDeep value
 
         AppDispatcher.dispatch
             type: ActionTypes.EDIT_ACCOUNT_REQUEST
-            value: {inputValues, newAccount}
+            value: {value, newAccount}
 
         XHRUtils.editAccount newAccount, (error, rawAccount) ->
             if error?
@@ -51,16 +51,16 @@ module.exports = AccountActionCreator =
                     type: ActionTypes.EDIT_ACCOUNT_SUCCESS
                     value: {rawAccount}
 
-    check: (inputValues, accountID) ->
+    check: ({value, accountID}) ->
         if accountID?
             account = AccountStore.getByID accountID
-            newAccount = account.mergeDeep(inputValues).toJS()
+            newAccount = account.mergeDeep(value).toJS()
         else
-            newAccount = inputValues
+            newAccount = value
 
         AppDispatcher.dispatch
             type: ActionTypes.CHECK_ACCOUNT_REQUEST
-            value: {inputValues, newAccount}
+            value: {value, newAccount}
 
         XHRUtils.checkAccount newAccount, (error, rawAccount) ->
             if error?

--- a/client/app/actions/account_action_creator.coffee
+++ b/client/app/actions/account_action_creator.coffee
@@ -87,6 +87,19 @@ module.exports = AccountActionCreator =
                     type: ActionTypes.REMOVE_ACCOUNT_SUCCESS
                     value: accountID
 
+    discover: (domain) ->
+        AppDispatcher.handleViewAction
+            type: ActionTypes.DISCOVER_REQUEST
+            value: {domain}
+        XHRUtils.accountDiscover domain, (error, provider) ->
+            if error
+                AppDispatcher.handleViewAction
+                    type: ActionTypes.DISCOVER_FAILURE
+                    value: {error, domain}
+            else
+                AppDispatcher.handleViewAction
+                    type: ActionTypes.DISCOVER_SUCCESS
+                    value: {domain, provider}
 
     saveEditTab: (tab) ->
         AppDispatcher.dispatch

--- a/client/app/components/account_config.coffee
+++ b/client/app/components/account_config.coffee
@@ -20,12 +20,10 @@ StoreWatchMixin      = require '../mixins/store_watch_mixin'
 
 {AccountActions} = require '../constants/app_constants'
 
-REQUIRED_FIELDS_NEW = [
+REQUIRED_FIELDS = [
     'label', 'name', 'login', 'password', 'imapServer', 'imapPort',
     'smtpServer', 'smtpPort', 'smtpMethod'
 ]
-
-REQUIRED_FIELDS_EDIT = REQUIRED_FIELDS_NEW
 
 TABS = ['account', 'mailboxes', 'signature']
 
@@ -66,28 +64,22 @@ module.exports = React.createClass
 
         return nstate
 
-    isOauth: ->
-        @state.selectedAccount?.get('oauthProvider')?
-
     isNew: ->
         not @state.selectedAccount?
 
     onTabChangesDoSubmit: (changes) ->
-        @onTabChanges changes, => @onSubmit()
+        @onTabChanges changes
+        @onSubmit()
 
-
-    # FIXME : normalement on devrait supprimer ça
-    # car l'url change à chaque fois
-    onTabChanges: (changes, callback = ->) ->
+    onTabChanges: (changes) ->
         nextstate =
-            editedAccount: @state.editedAccount.merge(changes)
+            editedAccount: @state.editedAccount.merge changes
             errors: Immutable.Map()
-
         if @state.selectedAccount?
             validErrors = @getLocalValidationErrors nextstate.editedAccount
             nextstate.errors = Immutable.Map validErrors
 
-        @setState nextstate, callback
+        @setState nextstate
 
     render: ->
         Container
@@ -125,7 +117,8 @@ module.exports = React.createClass
 
                 else
                     AccountConfigMain
-                        editedAccount: @state.editedAccount
+                        account: @state.editedAccount
+                        requestChange: @onTabChanges
                         isWaiting: @state.isWaiting
                         checking: @state.isChecking
                         onSubmit: @onSubmit
@@ -137,8 +130,7 @@ module.exports = React.createClass
 
     getLocalValidationErrors: (accountWithChanges) ->
         out = {}
-        requiredFields = if @isNew() then REQUIRED_FIELDS_NEW
-        else REQUIRED_FIELDS_EDIT
+        requiredFields = REQUIRED_FIELDS
 
         for field in requiredFields
             unless accountWithChanges.get(field)
@@ -150,22 +142,20 @@ module.exports = React.createClass
     # If everything is ok, it runs the checking, the account edition and the
     # creation depending on the current state and if the user submitted it
     # with the check button.
-    onSubmit: (event, check) ->
+    onSubmit: (event, isCheck) ->
         event?.preventDefault()
+
         errors = @getLocalValidationErrors @state.editedAccount
-
-        id = @state.editedAccount?.get('id')
-        accountValue = @state.editedAccount.toJS()
-
-        if Object.keys(errors).length > 0
+        if Object.keys(errors).length
             NotificationActionsCreator.alertError t 'account errors'
             @setState submitted: true, errors: Immutable.Map(errors)
+            return
 
-        else if check is true
-            AccountActionCreator.check accountValue, id
-
-        else if id
-            AccountActionCreator.edit accountValue, id
-
+        accountID = @state.editedAccount?.get('id')
+        value = @state.editedAccount.toJS()
+        if isCheck
+            AccountActionCreator.check {accountID, value}
+        else if accountID
+            AccountActionCreator.edit {accountID, value}
         else
-            AccountActionCreator.create accountValue
+            AccountActionCreator.create {value}

--- a/client/app/components/account_config.coffee
+++ b/client/app/components/account_config.coffee
@@ -75,6 +75,9 @@ module.exports = React.createClass
     onTabChangesDoSubmit: (changes) ->
         @onTabChanges changes, => @onSubmit()
 
+
+    # FIXME : normalement on devrait supprimer ça
+    # car l'url change à chaque fois
     onTabChanges: (changes, callback = ->) ->
         nextstate =
             editedAccount: @state.editedAccount.merge(changes)
@@ -123,7 +126,6 @@ module.exports = React.createClass
                 else
                     AccountConfigMain
                         editedAccount: @state.editedAccount
-                        requestChange: @onTabChanges
                         isWaiting: @state.isWaiting
                         checking: @state.isChecking
                         onSubmit: @onSubmit

--- a/client/app/components/account_config_input.coffee
+++ b/client/app/components/account_config_input.coffee
@@ -15,26 +15,13 @@ module.exports = AccountInput = React.createClass
         LinkedStateMixin
     ]
 
-    propTypes:
-        name: React.PropTypes.string.isRequired
-        error: React.PropTypes.string
+    # Update parent from child
+    # but not child from child (infinite case)
+    shouldComponentUpdate: (nextProps) ->
+        not _.isEmpty _.difference nextProps, @props
 
-        className: React.PropTypes.string
-        onClick: React.PropTypes.func
-        onInput: React.PropTypes.func
-        onBlur: React.PropTypes.func
-        type: React.PropTypes.oneOf [
-            'checkbox', 'textarea', 'email', 'text', 'password'
-        ]
-        valueLink: React.PropTypes.shape
-            value: React.PropTypes.any
-            requestChange: React.PropTypes.func.isRequired
-        options: (props) ->
-            if props.type is 'dropdown'
-                React.PropTypes.object.isRequired.apply this, arguments
-
-
-    getDefaultProps: -> type: 'text'
+    onChange: (event) ->
+        @props.valueLink.requestChange event.target?.value
 
     render: ->
         name = @props.name
@@ -55,14 +42,16 @@ module.exports = AccountInput = React.createClass
                     input
                         id: "mailbox-#{name}"
                         name: "mailbox-#{name}"
-                        checkedLink: @props.valueLink
+                        checkedLink: @props.valueLink.value
+                        onChange: @onChange
                         type: type
                         onClick: @props.onClick
                 else if type is 'textarea'
                     textarea
                         id: "mailbox-#{name}"
                         name: "mailbox-#{name}"
-                        valueLink: @props.valueLink
+                        valueLink: @props.valueLink.value
+                        onChange: @onChange
                         className: 'form-control'
                         placeholder: placeHolder
                         onBlur: @props.onBlur
@@ -71,14 +60,16 @@ module.exports = AccountInput = React.createClass
                     Dropdown
                         id: "mailbox-#{name}"
                         name: "mailbox-#{name}"
-                        valueLink: @props.valueLink
+                        valueLink: @props.valueLink.value
+                        onChange: @onChange
                         options: @props.options
                         allowUndefined: @props.allowUndefined
                 else
                     input
                         id: "mailbox-#{name}"
                         name: "mailbox-#{name}"
-                        valueLink: @props.valueLink
+                        valueLink: @props.valueLink.value
+                        onChange: @onChange
                         type: type
                         className: 'form-control'
                         placeholder: placeHolder

--- a/client/app/components/account_config_input.coffee
+++ b/client/app/components/account_config_input.coffee
@@ -5,20 +5,22 @@ React = require 'react'
 
 LinkedStateMixin = require 'react-addons-linked-state-mixin'
 
-
 # Input used in the account configuration/creation form. An account input can
 # display an error message below it.
 module.exports = AccountInput = React.createClass
     displayName: 'AccountInput'
 
-    mixins: [
-        LinkedStateMixin
-    ]
-
     # Update parent from child
     # or child from parent
     shouldComponentUpdate: (nextProps) ->
-        not _.isEqual nextProps.valueLink.value, @props.valueLink.value
+        # Check props update
+        # excluding valueLink (special case)
+        nextValue = nextProps.valueLink.value
+        unless (hasChanged = nextValue isnt @props.valueLink.value)
+            _props = _.omit @props, 'valueLink'
+            _nextProps = _.omit nextProps, 'valueLink'
+            hasChanged = not _.isEqual _props, _nextProps
+        hasChanged
 
     onChange: (event) ->
         type = event.target.getAttribute 'type'

--- a/client/app/components/account_config_input.coffee
+++ b/client/app/components/account_config_input.coffee
@@ -16,12 +16,16 @@ module.exports = AccountInput = React.createClass
     ]
 
     # Update parent from child
-    # but not child from child (infinite case)
+    # or child from parent
     shouldComponentUpdate: (nextProps) ->
-        not _.isEmpty _.difference nextProps, @props
+        not _.isEqual nextProps.valueLink.value, @props.valueLink.value
 
     onChange: (event) ->
-        @props.valueLink.requestChange event.target?.value
+        type = event.target.getAttribute 'type'
+        value = event.target.value
+        value = event.target.checked if type in ['checkbox', 'radio']
+
+        @props.valueLink.requestChange value
 
     render: ->
         name = @props.name
@@ -42,25 +46,22 @@ module.exports = AccountInput = React.createClass
                     input
                         id: "mailbox-#{name}"
                         name: "mailbox-#{name}"
-                        checkedLink: @props.valueLink.value
+                        checked: @props.valueLink.value
                         onChange: @onChange
                         type: type
-                        onClick: @props.onClick
                 else if type is 'textarea'
                     textarea
                         id: "mailbox-#{name}"
                         name: "mailbox-#{name}"
-                        valueLink: @props.valueLink.value
+                        value: @props.valueLink.value
                         onChange: @onChange
                         className: 'form-control'
                         placeholder: placeHolder
-                        onBlur: @props.onBlur
-                        onInput: @props.onInput
                 else if type is 'dropdown'
                     Dropdown
                         id: "mailbox-#{name}"
                         name: "mailbox-#{name}"
-                        valueLink: @props.valueLink.value
+                        value: @props.valueLink.value
                         onChange: @onChange
                         options: @props.options
                         allowUndefined: @props.allowUndefined
@@ -68,13 +69,11 @@ module.exports = AccountInput = React.createClass
                     input
                         id: "mailbox-#{name}"
                         name: "mailbox-#{name}"
-                        valueLink: @props.valueLink.value
+                        value: @props.valueLink.value
                         onChange: @onChange
                         type: type
                         className: 'form-control'
                         placeholder: placeHolder
-                        onBlur: @props.onBlur
-                        onInput: @props.onInput
 
             if @props.error
                 ErrorLine text: @props.error

--- a/client/app/components/account_config_main.coffee
+++ b/client/app/components/account_config_main.coffee
@@ -30,8 +30,10 @@ module.exports = AccountConfigMain = React.createClass
         smtpSSL: true
         imapAdvanced: false
 
+
     getInitialState: ->
         @getStateFromStores()
+
 
     componentWillReceiveProps: (nextProps) ->
         @setState @getStateFromStores nextProps
@@ -94,8 +96,10 @@ module.exports = AccountConfigMain = React.createClass
     componentDidMount: ->
         @dispatchDiscover()
 
+
     componentDidUpdate: ->
         @dispatchDiscover()
+
 
     buildInput: (name, attributes={}) ->
         value = @state[name]
@@ -108,8 +112,8 @@ module.exports = AccountConfigMain = React.createClass
               requestChange: (value) =>
                   @handleChange name, value
             error: @props.errors?.get name
-
         AccountInput _.extend {}, _defaultAttributes, attributes
+
 
     render: ->
         formClass = classNames
@@ -132,7 +136,8 @@ module.exports = AccountConfigMain = React.createClass
 
             @buildInput 'accountType', className: 'hidden'
 
-            # Display gmail warning if IMAP server is Gmail.
+            # Display gmail warning
+            # if IMAP server is Gmail.
             if @state.isGmail
                 @_renderGMAILSecurity()
 
@@ -142,17 +147,14 @@ module.exports = AccountConfigMain = React.createClass
             unless @state.isOauth
                 @_renderSendingServer()
 
-
             @_renderButtons()
+
 
     _renderReceivingServer: ->
         className = if @state.imapAdvanced then 'hide' else 'show'
 
         FieldSet text: t('account receiving server'),
             @buildInput 'imapServer'
-            @buildInput 'imapPort'
-            @buildInput 'imapSSL', type: 'checkbox'
-            @buildInput 'imapTLS', type: 'checkbox'
 
             div
                 className: "form-group advanced-imap-toggle",
@@ -162,6 +164,15 @@ module.exports = AccountConfigMain = React.createClass
                     t "account imap #{className} advanced"
 
             if @state.imapAdvanced
+                @buildInput 'imapPort'
+
+            if @state.imapAdvanced
+                @buildInput 'imapSSL', type: 'checkbox'
+
+            if @state.imapAdvanced
+                @buildInput 'imapTLS', type: 'checkbox'
+
+            if @state.imapAdvanced
                 @buildInput 'imapLogin'
 
 
@@ -169,9 +180,6 @@ module.exports = AccountConfigMain = React.createClass
         className = if @state.smtpAdvanced then 'hide' else 'show'
         FieldSet text: t('account sending server'),
             @buildInput 'smtpServer'
-            @buildInput 'smtpPort'
-            @buildInput 'smtpSSL', type: 'checkbox'
-            @buildInput 'smtpTLS', type: 'checkbox'
 
             div
                 className: "form-group advanced-smtp-toggle",
@@ -181,15 +189,27 @@ module.exports = AccountConfigMain = React.createClass
                     t "account smtp #{className} advanced"
 
             if @state.smtpAdvanced
+                @buildInput 'smtpPort'
+
+            if @state.smtpAdvanced
+                @buildInput 'smtpSSL', type: 'checkbox'
+
+            if @state.smtpAdvanced
+                @buildInput 'smtpTLS', type: 'checkbox'
+
+            if @state.smtpAdvanced
                 @buildInput 'smtpMethod',
                     type: 'dropdown'
                     options: SMTP_OPTIONS
                     allowUndefined: true
 
+            if @state.smtpAdvanced
                 @buildInput 'smtpLogin'
 
+            if @state.smtpAdvanced
                 @buildInput 'smtpPassword',
                     type: 'password'
+
 
     _renderGMAILSecurity: ->
         url = "https://www.google.com/settings/security/lesssecureapps"
@@ -208,6 +228,7 @@ module.exports = AccountConfigMain = React.createClass
                     target: '_blank'
                     href: 'https://accounts.google.com/DisplayUnlockCaptcha'
                     t 'gmail security link 2'
+
 
     _renderButtons: ->
         action = if @props.isWaiting then 'saving'
@@ -233,6 +254,7 @@ module.exports = AccountConfigMain = React.createClass
                     onClick: (event) => @props.onSubmit event, true
                     icon: 'ellipsis-h'
                     text: t 'account check'
+
 
     # FIXME : discover is dispatched
     # event when account is removed

--- a/client/app/components/account_config_main.coffee
+++ b/client/app/components/account_config_main.coffee
@@ -18,6 +18,7 @@ SMTP_OPTIONS =
     'PLAIN': t("account smtpMethod PLAIN")
 
 GOOGLE_IMAP = ['imap.googlemail.com', 'imap.gmail.com']
+GOOGLE_EMAIL = ['googlemail.com', 'gmail.com']
 
 TRIMMEDFIELDS = ['imapServer', 'imapPort', 'smtpServer', 'smtpPort']
 
@@ -89,6 +90,12 @@ module.exports = AccountConfigMain = React.createClass
         isSmtpTLS = @state?.smtpTLS and nextState.smtpTLS is undefined
         if nextState.smtpTLS or isSmtpTLS
             nextState.smtpPort = '587'
+
+        # Check domain from login
+        if _.isString nextState.domain
+            gmailDomain = _.find GOOGLE_EMAIL, (value) ->
+                -1 < nextState.domain.indexOf value
+            nextState.isGmail = gmailDomain?
 
         nextState
 

--- a/client/app/components/account_config_main.coffee
+++ b/client/app/components/account_config_main.coffee
@@ -234,8 +234,10 @@ module.exports = AccountConfigMain = React.createClass
                     icon: 'ellipsis-h'
                     text: t 'account check'
 
+    # FIXME : discover is dispatched
+    # event when account is removed
     dispatchDiscover: ->
-        # Attempt to discover default values depending on target server.
-        # The target server is guessed by the email given by the user.
-        if @state.domain?.length > 3
-            AccountActionCreator.discover @state.domain
+        # # Attempt to discover default values depending on target server.
+        # # The target server is guessed by the email given by the user.
+        # if @state.domain?.length > 3
+        #     AccountActionCreator.discover @state.domain

--- a/client/app/components/application.coffee
+++ b/client/app/components/application.coffee
@@ -19,6 +19,7 @@ MessageStore         = require '../stores/message_store'
 RouterStore          = require '../stores/router_store'
 SettingsStore        = require '../stores/settings_store'
 RefreshesStore       = require '../stores/refreshes_store'
+AccountStore         = require '../stores/account_store'
 StoreWatchMixin      = require '../mixins/store_watch_mixin'
 TooltipRefesherMixin = require '../mixins/tooltip_refresher_mixin'
 
@@ -40,7 +41,7 @@ Application = React.createClass
 
     mixins: [
         TooltipRefesherMixin
-        StoreWatchMixin [SettingsStore, RefreshesStore, RouterStore, MessageStore, LayoutStore]
+        StoreWatchMixin [SettingsStore, RefreshesStore, RouterStore, MessageStore, LayoutStore, AccountStore]
     ]
 
     getStateFromStores: (props) ->

--- a/client/app/components/application.coffee
+++ b/client/app/components/application.coffee
@@ -66,6 +66,12 @@ Application = React.createClass
         }
 
     render: ->
+        action = MessageActions.CREATE
+        composeURL = RouterGetter.getURL {action}
+
+        action = AccountActions.CREATE
+        newAccountURL = RouterGetter.getURL {action}
+
         div className: @state.className,
 
             div className: 'app',
@@ -75,8 +81,8 @@ Application = React.createClass
                     accountID       : @state.accountID
                     mailboxID       : @state.mailboxID
                     accounts        : RouterGetter.getAccounts().toArray()
-                    composeURL      : RouterGetter.getURL action: MessageActions.CREATE
-                    newAccountURL   : RouterGetter.getURL action: AccountActions.CREATE
+                    composeURL      : composeURL
+                    newAccountURL   : newAccountURL
 
                 main
                     className: @props.layout

--- a/client/app/components/menu.coffee
+++ b/client/app/components/menu.coffee
@@ -118,7 +118,6 @@ module.exports = Menu = React.createClass
     # FIXME : make a component for this
     renderMailBoxes: (account) ->
         accountID = account.get 'id'
-
         props = {
             key: 'account-' + accountID
             isSelected: accountID is RouterGetter.getAccountID()

--- a/client/app/components/menu.coffee
+++ b/client/app/components/menu.coffee
@@ -9,11 +9,15 @@ classNames = require 'classnames'
 colorhash = require '../utils/colorhash'
 
 LayoutActionCreator  = require '../actions/layout_action_creator'
+<<<<<<< dfd2af7ea66bc5a5ca79040000fe620820bc9c3e
 {MessageFilter, Tooltips, AccountActions} = require '../constants/app_constants'
 
 RouterStore = require '../stores/router_store'
 AccountStore = require '../stores/account_store'
 StoreWatchMixin = require '../mixins/store_watch_mixin'
+=======
+{Tooltips, AccountActions, MessageActions} = require '../constants/app_constants'
+>>>>>>> mailboxLink should redirect to the appropriate mailbox (not account adit)
 
 RouterGetter = require '../getters/router'
 IconGetter = require '../getters/icon'
@@ -117,9 +121,18 @@ module.exports = Menu = React.createClass
     # renders a single account and its submenu
     # TODO : make a component for this
     renderMailBoxes: (account) ->
+        # Goto the default mailbox of the account
+        action = MessageActions.SHOW_ALL
+        accountID = account.get 'id'
+        mailbox = RouterGetter.getCurrentMailbox(accountID)
+        mailboxID = mailbox?.get 'id'
+        mailboxURL = RouterGetter.getURL {action, mailboxID}
+
         props = {
-            key: 'account-' + (accountID = account.get 'id')
+            key: 'account-' + accountID
             isSelected: accountID is RouterGetter.getAccountID()
+            mailboxes: RouterGetter.getMailboxes()
+            mailboxURL: mailboxURL
             configURL: RouterGetter.getURL
                 action: AccountActions.EDIT
                 accountID: accountID
@@ -133,7 +146,7 @@ module.exports = Menu = React.createClass
             key: props.key,
             div className: 'account-title',
                 a
-                    href: props.configURL
+                    href: props.mailboxURL
                     role: 'menuitem'
                     className: 'account ' + className,
                     'data-toggle': 'tooltip'

--- a/client/app/components/menu.coffee
+++ b/client/app/components/menu.coffee
@@ -148,10 +148,6 @@ module.exports = Menu = React.createClass
                             className: 'account-details',
                                 span
                                     'data-account-id': props.key,
-                                    className: 'item-label display-label'
-                                    account.get 'label'
-                                span
-                                    'data-account-id': props.key,
                                     className: 'item-label display-login'
                                     account.get 'login'
 

--- a/client/app/components/menu.coffee
+++ b/client/app/components/menu.coffee
@@ -9,15 +9,11 @@ classNames = require 'classnames'
 colorhash = require '../utils/colorhash'
 
 LayoutActionCreator  = require '../actions/layout_action_creator'
-<<<<<<< dfd2af7ea66bc5a5ca79040000fe620820bc9c3e
-{MessageFilter, Tooltips, AccountActions} = require '../constants/app_constants'
+{MessageFilter, Tooltips, AccountActions, MessageActions} = require '../constants/app_constants'
 
 RouterStore = require '../stores/router_store'
 AccountStore = require '../stores/account_store'
 StoreWatchMixin = require '../mixins/store_watch_mixin'
-=======
-{Tooltips, AccountActions, MessageActions} = require '../constants/app_constants'
->>>>>>> mailboxLink should redirect to the appropriate mailbox (not account adit)
 
 RouterGetter = require '../getters/router'
 IconGetter = require '../getters/icon'

--- a/client/app/components/menu.coffee
+++ b/client/app/components/menu.coffee
@@ -120,7 +120,7 @@ module.exports = Menu = React.createClass
         # Goto the default mailbox of the account
         action = MessageActions.SHOW_ALL
         accountID = account.get 'id'
-        mailbox = RouterGetter.getCurrentMailbox(accountID)
+        mailbox = RouterGetter.getInbox(accountID)
         mailboxID = mailbox?.get 'id'
         mailboxURL = RouterGetter.getURL {action, mailboxID}
 

--- a/client/app/components/menu.coffee
+++ b/client/app/components/menu.coffee
@@ -117,9 +117,8 @@ module.exports = Menu = React.createClass
     # renders a single account and its submenu
     # TODO : make a component for this
     renderMailBoxes: (account) ->
-        accountID = account.get 'id'
         props = {
-            key: 'account-' + accountID
+            key: 'account-' + (accountID = account.get 'id')
             isSelected: accountID is RouterGetter.getAccountID()
             configURL: RouterGetter.getURL
                 action: AccountActions.EDIT
@@ -151,24 +150,13 @@ module.exports = Menu = React.createClass
                                     className: 'item-label display-login'
                                     account.get 'login'
 
-                    if props.progress?.get('errors')?.size
-                        span className: 'refresh-error',
-                            i
-                                className: 'fa warning',
-                                onClick: @displayErrors,
-                                props.progress
-
-                if props.isSelected
-                    a
-                        href: props.configURL
-                        className: 'mailbox-config menu-subaction',
-                        i
-                            'className': 'fa fa-cog'
-                            'aria-describedby': Tooltips.ACCOUNT_PARAMETERS
-                            'data-tooltip-direction': 'right'
-
-                if props.nbUnread > 0 and not props.progress
-                    span className: 'badge', props.nbUnread
+                a
+                    href: props.configURL
+                    className: 'mailbox-config menu-subaction',
+                    i
+                        'className': 'fa fa-cog'
+                        'aria-describedby': Tooltips.ACCOUNT_PARAMETERS
+                        'data-tooltip-direction': 'right'
 
             if props.isSelected
                 ul

--- a/client/app/components/menu.coffee
+++ b/client/app/components/menu.coffee
@@ -115,7 +115,7 @@ module.exports = Menu = React.createClass
             icon:           IconGetter.getMailboxIcon {type}
 
     # renders a single account and its submenu
-    # FIXME : make a component for this
+    # TODO : make a component for this
     renderMailBoxes: (account) ->
         accountID = account.get 'id'
         props = {
@@ -142,8 +142,7 @@ module.exports = Menu = React.createClass
                     'data-placement' : 'right',
                         i
                             className: 'avatar'
-                            style:
-                                backgroundColor: props.color
+                            style: backgroundColor: props.color
                             account.get('label')[0]
                         div
                             className: 'account-details',

--- a/client/app/constants/app_constants.coffee
+++ b/client/app/constants/app_constants.coffee
@@ -17,6 +17,9 @@ module.exports =
         'EDIT_ACCOUNT_TAB'          : 'EDIT_ACCOUNT_TAB'
         'SELECT_ACCOUNT'            : 'SELECT_ACCOUNT'
         'NEW_ACCOUNT_SETTING'       : 'NEW_ACCOUNT_SETTING'
+        'DISCOVER_REQUEST'          : 'DISCOVER_REQUEST'
+        'DISCOVER_SUCCESS'          : 'DISCOVER_SUCCESS'
+        'DISCOVER_FAILURE'          : 'DISCOVER_FAILURE'
 
         # Mailbox
         # 'MAILBOX_ADD'               : 'MAILBOX_ADD'

--- a/client/app/getters/router.coffee
+++ b/client/app/getters/router.coffee
@@ -119,13 +119,7 @@ class RouteGetter
             'INBOX' is mailbox.get 'label'
 
     getAccounts: ->
-        accountID = @getAccountID()
-        AccountStore.getAll().sort (account1, account2) ->
-            if accountID is account1.get('id')
-                return -1
-            if accountID is account2.get('id')
-                return 1
-            return 0
+        AccountStore.getAll()
 
     getAccountSignature: ->
         AccountStore.getSelected()?.get 'signature'

--- a/client/app/getters/router.coffee
+++ b/client/app/getters/router.coffee
@@ -147,8 +147,6 @@ class RouteGetter
                 unless (isEqual or isGlobal)
                     return mailbox?.get 'label'
 
-    # TODO : move this into getter
-    # this has nothing to do with store
     getEmptyMessage: ->
         filter = @getFilter()
         if @isFlags 'UNSEEN', filter.flags

--- a/client/app/getters/router.coffee
+++ b/client/app/getters/router.coffee
@@ -139,14 +139,16 @@ class RouteGetter
     getTags: (message) ->
         mailboxID = @getMailboxID()
         mailboxesIDs = Object.keys message.get 'mailboxIDs'
-        result = mailboxesIDs.map (id) =>
+        return _.uniq _.compact mailboxesIDs.map (id) =>
             if (mailbox = @getCurrentMailbox id)
-                isGlobal = MailboxFlags.ALL in mailbox.get 'attribs'
+                attribs = mailbox.get('attribs') or []
+                isGlobal = MailboxFlags.ALL in attribs
                 isEqual = mailboxID is id
                 unless (isEqual or isGlobal)
                     return mailbox?.get 'label'
-        _.uniq _.compact result
 
+    # TODO : move this into getter
+    # this has nothing to do with store
     getEmptyMessage: ->
         filter = @getFilter()
         if @isFlags 'UNSEEN', filter.flags

--- a/client/app/getters/router.coffee
+++ b/client/app/getters/router.coffee
@@ -65,7 +65,7 @@ class RouteGetter
         AccountStore.getSelectedTab()
 
     getModal: ->
-        LayoutStore.getModal()
+        RouterStore.getModalParams()
 
     isFlags: (name) ->
         flags = @getFilter()?.flags or []

--- a/client/app/getters/router.coffee
+++ b/client/app/getters/router.coffee
@@ -111,11 +111,14 @@ class RouteGetter
     isCurrentConversation: (conversationID) ->
         conversationID is @getCurrentMessage()?.get 'conversationID'
 
-    getCurrentMailbox: (mailboxID) ->
+    getMailbox: (mailboxID) ->
         AccountStore.getMailbox mailboxID
 
-    getInbox: ->
-        AccountStore.getAllMailboxes()?.find (mailbox) ->
+    getCurrentMailbox: ->
+        AccountStore.getMailbox()
+
+    getInbox: (accountID) ->
+        AccountStore.getAllMailboxes(accountID)?.find (mailbox) ->
             'INBOX' is mailbox.get 'label'
 
     getAccounts: ->
@@ -140,7 +143,7 @@ class RouteGetter
         mailboxID = @getMailboxID()
         mailboxesIDs = Object.keys message.get 'mailboxIDs'
         return _.uniq _.compact mailboxesIDs.map (id) =>
-            if (mailbox = @getCurrentMailbox id)
+            if (mailbox = @getMailbox id)
                 attribs = mailbox.get('attribs') or []
                 isGlobal = MailboxFlags.ALL in attribs
                 isEqual = mailboxID is id

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -231,12 +231,34 @@ class AccountStore extends Store
     getSelected: ->
         return _accounts.get _accountID
 
+<<<<<<< dfd2af7ea66bc5a5ca79040000fe620820bc9c3e
 
     getAllMailboxes: ->
         return _accounts.get @getAccountID()
             .get 'mailboxes'
             .sort _mailboxSort
 
+=======
+    getSelectedMailboxes: (accountID) ->
+        account = _accounts.get accountID if accountID
+        account ?= _selectedAccount
+        return account?.get('mailboxes').sort(_mailboxSort)
+
+    getSelectedMailbox: (accountID) ->
+        if (mailboxes = @getSelectedMailboxes(accountID))?.size
+            return mailboxes.first()
+        return @getDefaultMailbox()
+
+    getSelectedFavorites: ->
+        if (mailboxes = @getSelectedMailboxes())
+            ids = _selectedAccount?.get 'favorites'
+            if ids?
+                mailboxes = mailboxes
+                    .filter (box, key) -> key in ids
+                    .toOrderedMap()
+            else
+                mailboxes = mailboxes.toOrderedMap()
+>>>>>>> mailboxLink should redirect to the appropriate mailbox (not account adit)
 
     getMailbox: (mailboxID) ->
         mailboxID ?= _mailboxID

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -71,7 +71,7 @@ class AccountStore extends Store
     _setMailbox = (data) ->
         # on account creation, sometime socket send mailboxes updates
         # before the account has been saved locally
-        return true unless (account = _accounts.get _accountID)
+        return true unless (account = _accounts.get _accountID)?.size
 
         mailboxID = data.id
         mailboxes = account.get('mailboxes')
@@ -105,12 +105,11 @@ class AccountStore extends Store
         _mailboxID = mailboxID
         _tab = tab
 
-    _onAccountUpdated = (rawAccount) ->
+
+    _updateAccount = (rawAccount) ->
         account = AccountTranslator.toImmutable rawAccount
         accountID = account.get 'id'
         _accounts = _accounts.set accountID, account
-
-        _setCurrentAccount accountID
 
 
     ###

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -124,7 +124,7 @@ class AccountStore extends Store
 
             @emit 'change'
 
-        handle ActionTypes.ADD_ACCOUNT_REQUEST, ({inputValues}) ->
+        handle ActionTypes.ADD_ACCOUNT_REQUEST, ({value}) ->
             _newAccountWaiting = true
             @emit 'change'
 
@@ -153,7 +153,7 @@ class AccountStore extends Store
             @emit 'change'
 
 
-        handle ActionTypes.EDIT_ACCOUNT_REQUEST, ({inputValues}) ->
+        handle ActionTypes.EDIT_ACCOUNT_REQUEST, ({value}) ->
             _newAccountWaiting = true
             @emit 'change'
 

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -232,8 +232,9 @@ class AccountStore extends Store
         return _accounts.get _accountID
 
 
-    getAllMailboxes: ->
-        return _accounts.get @getAccountID()
+    getAllMailboxes: (accountID) ->
+        accountID ?= @getAccountID()
+        return _accounts.get accountID
             .get 'mailboxes'
             .sort _mailboxSort
 

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -231,23 +231,20 @@ class AccountStore extends Store
     getSelected: ->
         return _accounts.get _accountID
 
-<<<<<<< dfd2af7ea66bc5a5ca79040000fe620820bc9c3e
-
     getAllMailboxes: ->
         return _accounts.get @getAccountID()
             .get 'mailboxes'
             .sort _mailboxSort
 
-=======
     getSelectedMailboxes: (accountID) ->
-        account = _accounts.get accountID if accountID
+        account = _accounts.get accountID
         account ?= _selectedAccount
         return account?.get('mailboxes').sort(_mailboxSort)
 
     getSelectedMailbox: (accountID) ->
-        if (mailboxes = @getSelectedMailboxes(accountID))?.size
-            return mailboxes.first()
-        return @getDefaultMailbox()
+        accountID ?= _selectedAccount.get('id')
+        mailboxes = @getSelectedMailboxes(accountID)
+        return mailboxes?.first() or @getSelectedOrDefault()
 
     getSelectedFavorites: ->
         if (mailboxes = @getSelectedMailboxes())

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -237,12 +237,11 @@ class AccountStore extends Store
             .sort _mailboxSort
 
     getSelectedMailboxes: (accountID) ->
-        account = _accounts.get accountID
-        account ?= _selectedAccount
-        return account?.get('mailboxes').sort(_mailboxSort)
+        accountID ?= _selectedAccount?.get('id')
+        _accounts.get(accountID)?.get('mailboxes')
+            .sort(_mailboxSort)
 
     getSelectedMailbox: (accountID) ->
-        accountID ?= _selectedAccount.get('id')
         mailboxes = @getSelectedMailboxes(accountID)
         return mailboxes?.first() or @getSelectedOrDefault()
 

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -231,30 +231,12 @@ class AccountStore extends Store
     getSelected: ->
         return _accounts.get _accountID
 
+
     getAllMailboxes: ->
         return _accounts.get @getAccountID()
             .get 'mailboxes'
             .sort _mailboxSort
 
-    getSelectedMailboxes: (accountID) ->
-        accountID ?= _selectedAccount?.get('id')
-        _accounts.get(accountID)?.get('mailboxes')
-            .sort(_mailboxSort)
-
-    getSelectedMailbox: (accountID) ->
-        mailboxes = @getSelectedMailboxes(accountID)
-        return mailboxes?.first() or @getSelectedOrDefault()
-
-    getSelectedFavorites: ->
-        if (mailboxes = @getSelectedMailboxes())
-            ids = _selectedAccount?.get 'favorites'
-            if ids?
-                mailboxes = mailboxes
-                    .filter (box, key) -> key in ids
-                    .toOrderedMap()
-            else
-                mailboxes = mailboxes.toOrderedMap()
->>>>>>> mailboxLink should redirect to the appropriate mailbox (not account adit)
 
     getMailbox: (mailboxID) ->
         mailboxID ?= _mailboxID

--- a/client/app/stores/layout_store.coffee
+++ b/client/app/stores/layout_store.coffee
@@ -27,8 +27,6 @@ class LayoutStore extends Store
 
     _listModeCompact = false
 
-    _modal  = null
-
 
     ###
         Defines here the action handlers.
@@ -50,14 +48,6 @@ class LayoutStore extends Store
                 _previewSize = 80 if _previewSize > 80
             else
                 _previewSize = 50
-            @emit 'change'
-
-        handle ActionTypes.DISPLAY_MODAL, (value) ->
-            _modal = value
-            @emit 'change'
-
-        handle ActionTypes.HIDE_MODAL, (value) ->
-            _modal = null
             @emit 'change'
 
         handle ActionTypes.FOCUS, (path) ->
@@ -96,10 +86,6 @@ class LayoutStore extends Store
 
     getFocus: ->
         return _focus
-
-
-    getModal: ->
-        return _modal
 
 
     isShown: ->

--- a/client/app/stores/router_store.coffee
+++ b/client/app/stores/router_store.coffee
@@ -48,10 +48,6 @@ class RouterStore extends Store
     getFilter: ->
         _currentFilter
 
-    # FIXME: refactor filtering based on query object (see doc/routes.md
-    #        and router.coffee:_parseQuery)
-    setFilter: (params={}) ->
-
 
     getModalParams: ->
         return _modal

--- a/client/app/stores/router_store.coffee
+++ b/client/app/stores/router_store.coffee
@@ -204,12 +204,15 @@ class RouterStore extends Store
             @emit 'change'
 
         handle ActionTypes.REMOVE_ACCOUNT_SUCCESS, ->
-            _router?.navigate url: ''
+            # FIXME : move AccountStore actions here
+            _action = AccountActions.CREATE
+            @emit 'change'
 
         handle ActionTypes.ADD_ACCOUNT_SUCCESS, ({account, areMailboxesConfigured}) ->
-            accountID = account.id
-            action = if areMailboxesConfigured then MessageActions.SHOW_ALL else AccountActions.EDIT
-            _router?.navigate {accountID, action}
+            # FIXME : move AccountStore actions here
+            _action = if areMailboxesConfigured
+            then MessageActions.SHOW_ALL
+            else AccountActions.EDIT
 
             @emit 'change'
 

--- a/client/app/stores/router_store.coffee
+++ b/client/app/stores/router_store.coffee
@@ -216,19 +216,10 @@ class RouterStore extends Store
 
             @emit 'change'
 
+
         handle ActionTypes.MESSAGE_FETCH_SUCCESS, ->
             @emit 'change'
 
-<<<<<<< f03a004188fdbefc698d40dd7258bf59bebf65c9
-=======
-
-        handle ActionTypes.MESSAGE_TRASH_SUCCESS, (params) ->
-            if MessageActions.SHOW is _action
-                if (messageID = params?.next?.get 'id')
-                    _router.navigate @getURL {messageID}
-                else
-                    _action = MessageActions.SHOW_ALL
-                @emit 'change'
 
         handle ActionTypes.DISPLAY_MODAL, (params) ->
             _modal = params
@@ -239,7 +230,6 @@ class RouterStore extends Store
             @emit 'change'
 
 
->>>>>>> Fix modal : move into routerStore
 _toCamelCase = (value) ->
     return value.replace /\.(\w)*/gi, (match) ->
         part1 = match.substring 1, 2

--- a/client/app/stores/router_store.coffee
+++ b/client/app/stores/router_store.coffee
@@ -21,6 +21,8 @@ class RouterStore extends Store
     _nextURL = null
     _lastDate = null
 
+    _modal = null
+
     _currentFilter = _defaultFilter =
         sort: '-date'
 
@@ -45,6 +47,14 @@ class RouterStore extends Store
 
     getFilter: ->
         _currentFilter
+
+    # FIXME: refactor filtering based on query object (see doc/routes.md
+    #        and router.coffee:_parseQuery)
+    setFilter: (params={}) ->
+
+
+    getModalParams: ->
+        return _modal
 
 
     getURL: (params={}) ->
@@ -200,11 +210,33 @@ class RouterStore extends Store
             accountID = account.id
             action = if areMailboxesConfigured then MessageActions.SHOW_ALL else AccountActions.EDIT
             _router?.navigate {accountID, action}
+
             @emit 'change'
 
         handle ActionTypes.MESSAGE_FETCH_SUCCESS, ->
             @emit 'change'
 
+<<<<<<< f03a004188fdbefc698d40dd7258bf59bebf65c9
+=======
+
+        handle ActionTypes.MESSAGE_TRASH_SUCCESS, (params) ->
+            if MessageActions.SHOW is _action
+                if (messageID = params?.next?.get 'id')
+                    _router.navigate @getURL {messageID}
+                else
+                    _action = MessageActions.SHOW_ALL
+                @emit 'change'
+
+        handle ActionTypes.DISPLAY_MODAL, (params) ->
+            _modal = params
+            @emit 'change'
+
+        handle ActionTypes.HIDE_MODAL, (value) ->
+            _modal = null
+            @emit 'change'
+
+
+>>>>>>> Fix modal : move into routerStore
 _toCamelCase = (value) ->
     return value.replace /\.(\w)*/gi, (match) ->
         part1 = match.substring 1, 2

--- a/client/app/styles/_menu.styl
+++ b/client/app/styles/_menu.styl
@@ -44,11 +44,6 @@ subaction()
         display inline-block
         font-size 0.875em
 
-        .display-label
-            display block
-            font-size 1.25em
-            color grey-08
-
         .display-login
             font-weight normal
             font-style italic

--- a/client/app/utils/xhr_utils.coffee
+++ b/client/app/utils/xhr_utils.coffee
@@ -10,6 +10,8 @@ MessageStore = require '../stores/message_store'
 
 {MessageActions} = require '../constants/app_constants'
 
+discovery2Fields = require '../utils/discovery_to_fields'
+
 
 handleResponse = (callback, details...) ->
     # Prepare the handler to get `err`, `res` from superagent, and next the
@@ -155,10 +157,14 @@ module.exports =
         .end handleResponse callback, "removeAccount"
 
     accountDiscover: (domain, callback) ->
+        _callback = (error, provider) =>
+            unless error
+                infos = discovery2Fields(provider)
+            callback error, provider, infos
 
         request.get "provider/#{domain}"
         .set 'Accept', 'application/json'
-        .end handleResponse callback, "accountDiscover"
+        .end handleResponse _callback, "accountDiscover"
 
     search: (url, callback) ->
         request.get url


### PR DESCRIPTION
## Fix features
 - [x] discover is broken (but feature didnt work at all),
 - [x] clean ActionCreator,
 - [x] clean views,
 - [x] fix `add` account (didn't work anymore),
 - [x] fix `remove` account (didn't work anymore),
 - [x] fix `edit` account  (didn't work anymore), 
 - [x] fix accountMailbox link that was always redirect to `account/new`,
 - [x] accounts links should redirect to its related `mailbox`, not `account edit`,
 - [x] do not re-order mailbox when changing selected one,

## Remove features
 - [x] remove `default` configuration for IMAP/SMTP,
 - [x] delete `name` from `accountLink`,
