### PR TITLE
[refactor] Move accountID, mailboxID, messageID into RouterStore

### DIFF
--- a/client/app/actions/account_action_creator.coffee
+++ b/client/app/actions/account_action_creator.coffee
@@ -88,16 +88,16 @@ module.exports = AccountActionCreator =
                     value: accountID
 
     discover: (domain) ->
-        AppDispatcher.handleViewAction
+        AppDispatcher.dispatch
             type: ActionTypes.DISCOVER_REQUEST
             value: {domain}
         XHRUtils.accountDiscover domain, (error, provider) ->
             if error
-                AppDispatcher.handleViewAction
+                AppDispatcher.dispatch
                     type: ActionTypes.DISCOVER_FAILURE
                     value: {error, domain}
             else
-                AppDispatcher.handleViewAction
+                AppDispatcher.dispatch
                     type: ActionTypes.DISCOVER_SUCCESS
                     value: {domain, provider}
 

--- a/client/app/actions/account_action_creator.coffee
+++ b/client/app/actions/account_action_creator.coffee
@@ -3,7 +3,6 @@ AppDispatcher = require '../libs/flux/dispatcher/dispatcher'
 {ActionTypes} = require '../constants/app_constants'
 
 AccountStore = require '../stores/account_store'
-RouterStore = require '../stores/router_store'
 
 module.exports = AccountActionCreator =
 

--- a/client/app/actions/layout_action_creator.coffee
+++ b/client/app/actions/layout_action_creator.coffee
@@ -39,10 +39,6 @@ module.exports = LayoutActionCreator =
             type: ActionTypes.RESIZE_PREVIEW_PANE
             value: null
 
-    focus: (path) ->
-        AppDispatcher.dispatch
-            type: ActionTypes.FOCUS
-            value: path
 
     clearToasts: ->
         AppDispatcher.dispatch

--- a/client/app/actions/message_action_creator.coffee
+++ b/client/app/actions/message_action_creator.coffee
@@ -99,14 +99,14 @@ MessageActionCreator =
                 type: ActionTypes.MESSAGE_TRASH_SUCCESS
                 value: {target, ref, updated}
 
-    move: (target, from, to, callback) ->
+    move: (target, from, to) ->
         ref = refCounter++
         AppDispatcher.dispatch
             type: ActionTypes.MESSAGE_MOVE_REQUEST
             value: {target, ref, from, to}
 
-        ts = Date.now()
         # send request
+        ts = Date.now()
         XHRUtils.batchMove target, from, to, (error, updated) =>
             if error
                 AppDispatcher.dispatch
@@ -123,7 +123,6 @@ MessageActionCreator =
                     type: ActionTypes.MESSAGE_MOVE_SUCCESS
                     value: {target, ref, updated}
 
-            callback? error, updated
 
     mark: (target, flagAction) ->
         ref = refCounter++

--- a/client/app/actions/message_action_creator.coffee
+++ b/client/app/actions/message_action_creator.coffee
@@ -4,7 +4,6 @@ AppDispatcher = require '../libs/flux/dispatcher/dispatcher'
 
 XHRUtils      = require '../utils/xhr_utils'
 
-AccountStore  = require "../stores/account_store"
 MessageStore  = require '../stores/message_store'
 
 refCounter = 1
@@ -20,7 +19,6 @@ MessageActionCreator =
         AppDispatcher.dispatch
             type: ActionTypes.RECEIVE_RAW_MESSAGE
             value: message
-
 
     send: (action, message) ->
         conversationID = message.conversationID

--- a/client/app/actions/router_action_creator.coffee
+++ b/client/app/actions/router_action_creator.coffee
@@ -9,7 +9,9 @@ RouterStore = require '../stores/router_store'
 RouterActionCreator =
 
     getCurrentPage: ->
-        url = RouterStore.getCurrentURL()
+        # Always load messagesList
+        action = MessageActions.SHOW_ALL
+        url = RouterStore.getCurrentURL {action}
         AppDispatcher.dispatch
             type: ActionTypes.MESSAGE_FETCH_REQUEST
             value: {url}

--- a/client/app/actions/router_action_creator.coffee
+++ b/client/app/actions/router_action_creator.coffee
@@ -59,6 +59,25 @@ RouterActionCreator =
         @gotoCurrentPage {url, page}
 
 
+    gotoMessage: (params={}) ->
+        {messageID, mailboxID} = params
+        messageID ?= RouterStore.getMessageID()
+        mailboxID ?= RouterStore.getMailboxID()
+        action = MessageActions.SHOW
+        AppDispatcher.dispatch
+            type: ActionTypes.ROUTE_CHANGE
+            value: {messageID, mailboxID, action}
+
+
+    closeMessage: (params={}) ->
+        {mailboxID} = params
+        mailboxID ?= RouterStore.getMailboxID()
+        action = MessageActions.SHOW_ALL
+        AppDispatcher.dispatch
+            type: ActionTypes.ROUTE_CHANGE
+            value: {mailboxID, action}
+
+
     getConversation: (conversationID) ->
         page = _getPage()
         timestamp = (new Date()).toISOString()

--- a/client/app/actions/router_action_creator.coffee
+++ b/client/app/actions/router_action_creator.coffee
@@ -14,10 +14,13 @@ RouterActionCreator =
             type: ActionTypes.MESSAGE_FETCH_REQUEST
             value: {url}
 
+
     getNextPage: ->
-        AppDispatcher.dispatch
-            type: ActionTypes.MESSAGE_FETCH_REQUEST
-            value: {url: RouterStore.getNextURL()}
+        if (hasNextPage = RouterStore.hasNextPage())
+            url = RouterStore.getNextURL()
+            AppDispatcher.dispatch
+                type: ActionTypes.MESSAGE_FETCH_REQUEST
+                value: {url}
 
 
     addFilter: (params) ->

--- a/client/app/actions/router_action_creator.coffee
+++ b/client/app/actions/router_action_creator.coffee
@@ -8,11 +8,16 @@ RouterStore = require '../stores/router_store'
 
 RouterActionCreator =
 
-    getNextPage: ->
-        action = MessageActions.PAGE_NEXT
+    getCurrentPage: (payload) ->
+        url = RouterStore.getCurrentURL payload
         AppDispatcher.dispatch
             type: ActionTypes.MESSAGE_FETCH_REQUEST
-            value: {action}
+            value: {url}
+
+    getNextPage: ->
+        AppDispatcher.dispatch
+            type: ActionTypes.MESSAGE_FETCH_REQUEST
+            value: {url: RouterStore.getNextURL()}
 
 
     addFilter: (params) ->

--- a/client/app/actions/router_action_creator.coffee
+++ b/client/app/actions/router_action_creator.coffee
@@ -8,8 +8,8 @@ RouterStore = require '../stores/router_store'
 
 RouterActionCreator =
 
-    getCurrentPage: (payload) ->
-        url = RouterStore.getCurrentURL payload
+    getCurrentPage: ->
+        url = RouterStore.getCurrentURL()
         AppDispatcher.dispatch
             type: ActionTypes.MESSAGE_FETCH_REQUEST
             value: {url}

--- a/client/app/actions/router_action_creator.coffee
+++ b/client/app/actions/router_action_creator.coffee
@@ -59,6 +59,15 @@ RouterActionCreator =
         @gotoCurrentPage {url, page}
 
 
+    gotoCompose: (params={}) ->
+        {messageID, mailboxID} = params
+        action = MessageActions.NEW
+        mailboxID ?= RouterStore.getMailboxID()
+        AppDispatcher.dispatch
+            type: ActionTypes.ROUTE_CHANGE
+            value: {mailboxID, messageID, action}
+
+
     gotoMessage: (params={}) ->
         {messageID, mailboxID, action} = params
         messageID ?= RouterStore.getMessageID()
@@ -136,16 +145,6 @@ RouterActionCreator =
         AppDispatcher.dispatch
             type: ActionTypes.ROUTE_CHANGE
             value: {query, action}
-
-
-    navigate: (params={}) ->
-        {url} = params
-        url ?= RouterStore.getURL params
-
-        if url
-            # Update URL && context
-            router = RouterStore.getRouter()
-            router.navigate url, trigger: true
 
 
 _getPageKey = ->

--- a/client/app/actions/router_action_creator.coffee
+++ b/client/app/actions/router_action_creator.coffee
@@ -7,38 +7,77 @@ XHRUtils = require '../utils/xhr_utils'
 
 {ActionTypes, MessageActions} = require '../constants/app_constants'
 
+_pages = {}
+_nextURL = {}
+
 RouterActionCreator =
 
     getCurrentPage: (params={}) ->
-        {url} = params
+        {url, page} = params
 
         # Always load messagesList
         action = MessageActions.SHOW_ALL
+        timestamp = (new Date()).toISOString()
         url ?= RouterStore.getCurrentURL {action}
+        page ?= _getPage()
 
-        mailboxID = RouterStore.getMailboxID()
-        messageID = RouterStore.getMessageID()
+        AppDispatcher.dispatch
+            type: ActionTypes.MESSAGE_FETCH_REQUEST
+            value: {url, timestamp, page}
+
+        XHRUtils.fetchMessagesByFolder url, (error,result) =>
+            if error?
+                AppDispatcher.dispatch
+                    type: ActionTypes.MESSAGE_FETCH_FAILURE
+                    value: {error, url, timestamp, page}
+            else
+                AppDispatcher.dispatch
+                    type: ActionTypes.MESSAGE_FETCH_SUCCESS
+                    value: {result, url, timestamp, page}
+
+
+                # Save messagesLength per page
+                # to get the correct pageAfter param
+                # for getNext handles
+                _setNextURL result
+
+                # Missing Messages into Conversation
+                messageID = RouterStore.getMessageID()
+                length = RouterStore.getConversationLength {messageID}
+                conversation = RouterStore.getConversation messageID
+                if (length and conversation?.length) and conversation?.length isnt length
+                    conversationID = conversation[0].get 'conversationID'
+                    @getConversation conversationID
+
+                # Fetch missing messages
+                else if RouterStore.isMissingMessages()
+                    @getNextPage()
+
+
+    getNextPage: ->
+        url = _getNextURL()
+        page = _addPage()
+        @getCurrentPage {url, page}
+
+
+    getConversation: (conversationID) ->
+        page = _getPage()
         timestamp = (new Date()).toISOString()
 
         AppDispatcher.dispatch
             type: ActionTypes.MESSAGE_FETCH_REQUEST
-            value: {timestamp, messageID, mailboxID}
+            value: {conversationID, timestamp, page}
 
-        XHRUtils.fetchMessagesByFolder url, (error,result) ->
+        XHRUtils.fetchConversation {conversationID}, (error, messages) =>
             if error?
                 AppDispatcher.dispatch
                     type: ActionTypes.MESSAGE_FETCH_FAILURE
-                    value: {error, timestamp}
+                    value: {error, conversationID, timestamp, page}
             else
+                result = {messages}
                 AppDispatcher.dispatch
                     type: ActionTypes.MESSAGE_FETCH_SUCCESS
-                    value: {result, timestamp, messageID, mailboxID}
-
-
-    getNextPage: ->
-        if RouterStore.hasNextPage()
-            url = RouterStore.getNextURL()
-            @getCurrentPage {url}
+                    value: {result, conversationID, timestamp, page}
 
 
     addFilter: (params) ->
@@ -68,6 +107,7 @@ RouterActionCreator =
         # then into routerStore, use navigate
         @navigate url: RouterStore.getCurrentURL {filter, isServer: false}
 
+
     navigate: (params={}) ->
         {url} = params
         url ?= RouterStore.getURL params
@@ -76,5 +116,47 @@ RouterActionCreator =
             # Update URL && context
             router = RouterStore.getRouter()
             router.navigate url, trigger: true
+
+
+_getPageKey = ->
+    mailboxID = RouterStore.getMailboxID()
+    query = RouterStore.getQuery()
+    "#{mailboxID}#{query}"
+
+
+_getPage = ->
+    key = _getPageKey()
+    _pages[key] ?= -1
+    _pages[key]
+
+
+_addPage = ->
+    key = _getPageKey()
+    _pages[key] ?= -1
+    ++_pages[key]
+
+
+_getNextURI = ->
+    key = _getPageKey()
+    page = _getPage() + 1
+    "#{key}-#{page}"
+
+
+_getNextURL = ->
+    key = _getNextURI()
+    _nextURL[key]
+
+
+# Get URL from last fetch result
+# not from the list that is not reliable
+_setNextURL = ({messages}) ->
+    key = _getNextURI()
+
+    # Do not overwrite result
+    # that has no reasons to changes
+    if _nextURL[key] is undefined
+        filter = pageAfter: _.last(messages)?.date
+        _nextURL[key] = RouterStore.getCurrentURL {filter}
+
 
 module.exports = RouterActionCreator

--- a/client/app/actions/router_action_creator.coffee
+++ b/client/app/actions/router_action_creator.coffee
@@ -155,8 +155,9 @@ _setNextURL = ({messages}) ->
     # Do not overwrite result
     # that has no reasons to changes
     if _nextURL[key] is undefined
+        action = MessageActions.SHOW_ALL
         filter = pageAfter: _.last(messages)?.date
-        _nextURL[key] = RouterStore.getCurrentURL {filter}
+        _nextURL[key] = RouterStore.getCurrentURL {filter, action}
 
 
 module.exports = RouterActionCreator

--- a/client/app/actions/router_action_creator.coffee
+++ b/client/app/actions/router_action_creator.coffee
@@ -35,7 +35,6 @@ RouterActionCreator =
                     type: ActionTypes.MESSAGE_FETCH_SUCCESS
                     value: {result, url, timestamp, page}
 
-
                 # Save messagesLength per page
                 # to get the correct pageAfter param
                 # for getNext handles
@@ -50,7 +49,7 @@ RouterActionCreator =
                     @getConversation conversationID
 
                 # Fetch missing messages
-                else if RouterStore.isMissingMessages()
+                if RouterStore.isMissingMessages()
                     @getNextPage()
 
 

--- a/client/app/actions/router_action_creator.coffee
+++ b/client/app/actions/router_action_creator.coffee
@@ -12,7 +12,7 @@ _nextURL = {}
 
 RouterActionCreator =
 
-    getCurrentPage: (params={}) ->
+    gotoCurrentPage: (params={}) ->
         {url, page} = params
 
         # Always load messagesList
@@ -50,13 +50,13 @@ RouterActionCreator =
 
                 # Fetch missing messages
                 if RouterStore.isMissingMessages()
-                    @getNextPage()
+                    @gotoNextPage()
 
 
-    getNextPage: ->
+    gotoNextPage: ->
         url = _getNextURL()
         page = _addPage()
-        @getCurrentPage {url, page}
+        @gotoCurrentPage {url, page}
 
 
     getConversation: (conversationID) ->

--- a/client/app/actions/router_action_creator.coffee
+++ b/client/app/actions/router_action_creator.coffee
@@ -5,7 +5,7 @@ AppDispatcher = require '../libs/flux/dispatcher/dispatcher'
 RouterStore = require '../stores/router_store'
 XHRUtils = require '../utils/xhr_utils'
 
-{ActionTypes, MessageActions} = require '../constants/app_constants'
+{ActionTypes, MessageActions, SearchActions} = require '../constants/app_constants'
 
 _pages = {}
 _nextURL = {}
@@ -60,10 +60,10 @@ RouterActionCreator =
 
 
     gotoMessage: (params={}) ->
-        {messageID, mailboxID} = params
+        {messageID, mailboxID, action} = params
         messageID ?= RouterStore.getMessageID()
         mailboxID ?= RouterStore.getMailboxID()
-        action = MessageActions.SHOW
+        action ?= MessageActions.SHOW
         AppDispatcher.dispatch
             type: ActionTypes.ROUTE_CHANGE
             value: {messageID, mailboxID, action}
@@ -76,6 +76,10 @@ RouterActionCreator =
         AppDispatcher.dispatch
             type: ActionTypes.ROUTE_CHANGE
             value: {mailboxID, action}
+
+
+    showMessageList: (params={}) ->
+        @closeMessage params
 
 
     getConversation: (conversationID) ->
@@ -124,6 +128,14 @@ RouterActionCreator =
         # FIXME : use distacher instead
         # then into routerStore, use navigate
         @navigate url: RouterStore.getCurrentURL {filter, isServer: false}
+
+
+    searchAll: (params={}) ->
+        {query} = params
+        action = SearchActions.SHOW_ALL
+        AppDispatcher.dispatch
+            type: ActionTypes.ROUTE_CHANGE
+            value: {query, action}
 
 
     navigate: (params={}) ->

--- a/client/app/components/account_config.coffee
+++ b/client/app/components/account_config.coffee
@@ -41,10 +41,10 @@ module.exports = React.createClass
         nstate = {}
 
         # dont overwrite editedAccount when stores state changed
-        nstate.serverErrors      = AccountStore.getErrors()
+        nstate.serverErrors      = RouterStore.getErrors()
         nstate.selectedAccount   = RouterStore.getAccount()
-        nstate.isWaiting         = AccountStore.isWaiting()
-        nstate.isChecking        = AccountStore.isChecking()
+        nstate.isWaiting         = RouterStore.isWaiting()
+        nstate.isChecking        = RouterStore.isChecking()
         nstate.tab               = RouterGetter.getSelectedTab()
 
         unless (nstate.editedAccount = nstate.selectedAccount)

--- a/client/app/components/account_config.coffee
+++ b/client/app/components/account_config.coffee
@@ -15,6 +15,7 @@ AccountConfigMailboxes = React.createFactory require './account_config_mailboxes
 AccountConfigSignature = React.createFactory require './account_config_signature'
 
 AccountStore         = require '../stores/account_store'
+RouterStore         = require '../stores/router_store'
 SettingsStore        = require '../stores/settings_store'
 StoreWatchMixin      = require '../mixins/store_watch_mixin'
 
@@ -41,7 +42,7 @@ module.exports = React.createClass
 
         # dont overwrite editedAccount when stores state changed
         nstate.serverErrors      = AccountStore.getErrors()
-        nstate.selectedAccount   = AccountStore.getSelected()
+        nstate.selectedAccount   = RouterStore.getAccount()
         nstate.isWaiting         = AccountStore.isWaiting()
         nstate.isChecking        = AccountStore.isChecking()
         nstate.tab               = RouterGetter.getSelectedTab()

--- a/client/app/components/application.coffee
+++ b/client/app/components/application.coffee
@@ -14,12 +14,9 @@ AccountConfig   = React.createFactory require './account_config'
 Compose         = React.createFactory require './compose'
 
 # React Mixins
-LayoutStore          = require '../stores/layout_store'
-MessageStore         = require '../stores/message_store'
 RouterStore          = require '../stores/router_store'
 SettingsStore        = require '../stores/settings_store'
 RefreshesStore       = require '../stores/refreshes_store'
-AccountStore         = require '../stores/account_store'
 StoreWatchMixin      = require '../mixins/store_watch_mixin'
 TooltipRefesherMixin = require '../mixins/tooltip_refresher_mixin'
 
@@ -41,7 +38,7 @@ Application = React.createClass
 
     mixins: [
         TooltipRefesherMixin
-        StoreWatchMixin [SettingsStore, RefreshesStore, RouterStore, MessageStore, LayoutStore, AccountStore]
+        StoreWatchMixin [SettingsStore, RefreshesStore, RouterStore]
     ]
 
     getStateFromStores: (props) ->
@@ -54,9 +51,6 @@ Application = React.createClass
         mailbox = RouterGetter.getCurrentMailbox()
         return {
             mailboxID       : (mailboxID = mailbox?.get 'id')
-            nbTotal         : mailbox?.get('nbTotal') or 0
-            nbUnread        : mailbox?.get('nbUnread') or 0
-            nbRecent        : mailbox?.get('nbRecent') or 0
             accountID       : RouterGetter.getAccountID()
             messageID       : RouterGetter.getCurrentMessageID()
             action          : RouterGetter.getAction()
@@ -76,7 +70,6 @@ Application = React.createClass
         isAccount = -1 < @state.action?.indexOf 'account'
 
         div className: @state.className,
-
             div className: 'app',
                 Menu
                     ref             : 'menu'

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -203,7 +203,7 @@ module.exports = React.createClass
     # selection and message information.
     finalRedirect: ->
         # FIXME : it should be into message_action_creator
-        RouterActionCreator.navigate
+        RouterActionCreator.gotoMessage
             messageID: @state.id
 
     # Cancel brings back to default view.

--- a/client/app/components/compose.coffee
+++ b/client/app/components/compose.coffee
@@ -265,14 +265,16 @@ module.exports = React.createClass
             # Check for Updates
             @resetChange message
 
-            # Refresh URL
-            # to save temporary info
             unless @state.id
+                # Update Info before the unmount
+                # that will autosave the message
                 @state.id = message.id
                 @state.conversationID = message.conversationID
-                RouterActionCreator.navigate
+
+                # Refresh page with the right messageID
+                RouterActionCreator.gotoMessage
                     action: MessageActions.EDIT
-                    messageID: @state.id
+                    messageID: message.id
                 return
 
             else if _.isFunction success

--- a/client/app/components/conversation.coffee
+++ b/client/app/components/conversation.coffee
@@ -10,12 +10,11 @@ DomUtils = require '../utils/dom_utils'
 Message             = React.createFactory require './message'
 ToolbarConversation = React.createFactory require './toolbar_conversation'
 
+# FIXME : use Getters instead of Stores
+LayoutStore         = require '../stores/layout_store'
 SettingsStore = require '../stores/settings_store'
 RouterGetter = require '../getters/router'
 
-# FIXME : use Getters instead of Stores
-MessageStore        = require '../stores/message_store'
-LayoutStore         = require '../stores/layout_store'
 SelectionStore       = require '../stores/selection_store'
 StoreWatchMixin      = require '../mixins/store_watch_mixin'
 
@@ -23,7 +22,7 @@ module.exports = React.createClass
     displayName: 'Conversation'
 
     mixins: [
-        StoreWatchMixin [SelectionStore, MessageStore]
+        StoreWatchMixin [SelectionStore]
     ]
 
     componentDidMount: ->
@@ -32,15 +31,14 @@ module.exports = React.createClass
     componentDidUpdate: ->
         @_initScroll()
 
-    getStateFromStores: ->
+    getStateFromStores: (props) ->
         return {
             message: RouterGetter.getMessage()
             conversation: RouterGetter.getConversation()
+            trashMailbox: RouterGetter.getTrashMailbox()
         }
 
-    renderMessage: (message, index) ->
-        accounts = RouterGetter.getAccounts()
-        accountID = RouterGetter.getAccountID()
+    renderMessage: (message) ->
         messageID = message.get 'id'
         Message
             ref                 : 'message'
@@ -50,7 +48,7 @@ module.exports = React.createClass
             url                 : RouterGetter.getURL {messageID}
             selectedMailboxID   : @props.mailboxID
             useIntents          : LayoutStore.intentAvailable()
-            trashMailbox        : accounts[accountID]?.trashMailbox
+            trashMailbox        : @state.trashMailbox
             displayHTML         : SettingsStore.get 'messageDisplayHTML'
             displayImages       : SettingsStore.get 'messageDisplayImages'
             confirmDelete       : SettingsStore.get 'messageConfirmDelete'

--- a/client/app/components/conversation.coffee
+++ b/client/app/components/conversation.coffee
@@ -14,7 +14,6 @@ SettingsStore = require '../stores/settings_store'
 RouterGetter = require '../getters/router'
 
 # FIXME : use Getters instead of Stores
-AccountStore        = require '../stores/account_store'
 MessageStore        = require '../stores/message_store'
 LayoutStore         = require '../stores/layout_store'
 SelectionStore       = require '../stores/selection_store'
@@ -40,7 +39,7 @@ module.exports = React.createClass
         }
 
     renderMessage: (message, index) ->
-        accounts = AccountStore.getAll()
+        accounts = RouterGetter.getAccounts()
         accountID = RouterGetter.getAccountID()
         messageID = message.get 'id'
         Message

--- a/client/app/components/conversation.coffee
+++ b/client/app/components/conversation.coffee
@@ -41,8 +41,7 @@ module.exports = React.createClass
     renderMessage: (message) ->
         messageID = message.get 'id'
         Message
-            ref                 : 'message'
-            key                 : 'message-' + messageID
+            key                 : 'message-detail-' + messageID
             message             : message
             active              : @props.messageID is messageID
             url                 : RouterGetter.getURL {messageID}

--- a/client/app/components/frame.coffee
+++ b/client/app/components/frame.coffee
@@ -1,0 +1,40 @@
+React = require 'react'
+ReactDOM  = require 'react-dom'
+
+{iframe, div} = React.DOM
+
+_counter = -1
+_loadMax = 10
+
+module.exports =  Frame = React.createClass
+    displayName: 'Frame'
+
+    render: ->
+        iframe
+            className: 'content'
+            src: 'about:blank'
+            allowTransparency: false
+            frameBorder: 0
+
+    componentDidMount: ->
+        @renderFrameContents()
+
+    getDocument: ->
+        element = ReactDOM.findDOMNode @
+        doc = element.contentDocument
+        doc ?= element.contentWindow?.document
+        doc
+
+    renderFrameContents: ->
+        # doc = @getDocument()
+        if (doc = @getDocument())?.readyState is 'complete'
+            ReactDOM.render @props.children, doc.body
+        else if _loadMax < ++_counter
+            setTimeout @renderFrameContents, 0
+
+    componentDidUpdate: ->
+        @renderFrameContents()
+
+    componentWillUnmount: ->
+        if (doc = @getDocument())
+            ReactDOM.unmountComponentAtNode doc.body

--- a/client/app/components/menu.coffee
+++ b/client/app/components/menu.coffee
@@ -86,19 +86,12 @@ module.exports = Menu = React.createClass
                     onClick: -> Mousetrap.trigger '?'
 
     renderMailboxesFlags: (params={}) ->
-        {flags, type, progress, slug} = params
+        {flags, type, progress, slug, total, unread} = params
 
         mailbox = RouterGetter.getInbox()
         mailboxURL = RouterGetter.getURL
             mailboxID: (mailboxID = mailbox.get 'id')
             filter: {flags}
-
-        # No way to get this data for flagged email
-        # TODO : make a patch here:
-        # https://github.com/cozy/cozy-emails/blob/master/server/models/requests.coffee#L50-L52
-        total = if 'flagged' isnt slug then mailbox?.get('nbTotal') else 0
-        unread = if 'flagged' isnt slug then mailbox?.get('nbUnread') else 0
-        recent = if 'flagged' isnt slug then mailbox?.get('nbRecent') else 0
 
         MenuMailboxItem
             accountID:      RouterGetter.getAccountID()
@@ -112,7 +105,6 @@ module.exports = Menu = React.createClass
             progress:       progress
             total:          total
             unread:         unread
-            recent:         recent
             icon:           IconGetter.getMailboxIcon {type}
 
     # renders a single account and its submenu
@@ -199,10 +191,14 @@ module.exports = Menu = React.createClass
                         type: 'unreadMailbox'
                         flags: MessageFilter.UNSEEN
                         progress: props.progress
+                        total: (total = RouterStore.getInbox().get 'nbUnread')
+                        unread: total
                         slug: 'unread'
 
                     @renderMailboxesFlags
                         type: 'flaggedMailbox'
                         flags: MessageFilter.FLAGGED
                         progress: props.progress
+                        total: (total = RouterStore.getInbox().get 'nbFlagged')
+                        unread: total
                         slug: 'flagged'

--- a/client/app/components/menu.coffee
+++ b/client/app/components/menu.coffee
@@ -12,7 +12,6 @@ LayoutActionCreator  = require '../actions/layout_action_creator'
 {MessageFilter, Tooltips, AccountActions, MessageActions} = require '../constants/app_constants'
 
 RouterStore = require '../stores/router_store'
-AccountStore = require '../stores/account_store'
 StoreWatchMixin = require '../mixins/store_watch_mixin'
 
 RouterGetter = require '../getters/router'
@@ -22,7 +21,7 @@ module.exports = Menu = React.createClass
     displayName: 'Menu'
 
     mixins: [
-        StoreWatchMixin [AccountStore, RouterStore]
+        StoreWatchMixin [RouterStore]
     ]
 
     getStateFromStores: ->

--- a/client/app/components/menu.coffee
+++ b/client/app/components/menu.coffee
@@ -123,7 +123,7 @@ module.exports = Menu = React.createClass
         accountID = account.get 'id'
         mailbox = RouterGetter.getInbox(accountID)
         mailboxID = mailbox?.get 'id'
-        mailboxURL = RouterGetter.getURL {action, mailboxID}
+        mailboxURL = RouterGetter.getURL {action, mailboxID, resetFilter: true}
 
         props = {
             key: 'account-' + accountID

--- a/client/app/components/message-content.coffee
+++ b/client/app/components/message-content.coffee
@@ -1,11 +1,7 @@
-_     = require 'underscore'
 React = require 'react'
-ApiUtils = require '../utils/api_utils'
 
-{
-    div, article, header, footer, ul, li, span, i, p, a, button, pre,
-    iframe
-} = React.DOM
+frame  = React.createFactory require '../components/frame'
+{div, span, i, p, button} = React.DOM
 
 
 module.exports = MessageContent = React.createClass
@@ -26,78 +22,11 @@ module.exports = MessageContent = React.createClass
                                 ref: 'imagesDisplay',
                                 onClick: @props.displayImages,
                                 t 'message images display'
-                iframe
-                    name: "frame-#{@props.messageID}"
-                    className: 'content',
-                    ref: 'content',
-                    src: 'about:blank'
-                    allowTransparency: false,
-                    frameBorder: 0
+
+                frame null,
+                    span dangerouslySetInnerHTML: { __html: @props.html }
+
         else
             div className: 'row',
                 div className: 'preview', ref: 'content',
                     p dangerouslySetInnerHTML: { __html: @props.rich }
-
-
-    _initFrame: (type) ->
-        # - resize the frame to the height of its content
-        # - if images are not displayed, create the function to display them
-        #   and resize the frame
-        if @props.displayHTML and @refs.content
-            frame = @refs.content
-            doc = frame.contentDocument or frame.contentWindow?.document
-            checkResize = false # disabled for now
-            step = 0
-            # Function called on frame load
-            # Inject HTML content of the message inside the frame, then
-            # update frame height to remove scrollbar
-            loadContent = (e) =>
-                step = 0
-                doc = frame.contentDocument or frame.contentWindow?.document
-                if doc?
-                    doc.documentElement.innerHTML = @props.html
-                    ApiUtils.customEvent "MESSAGE_LOADED", @props.messageID
-                    updateHeight = (e) ->
-                        height = doc.documentElement.scrollHeight
-                        if height < 60
-                            frame.style.height = "60px"
-                        else if height > frame.style.height
-                            frame.style.height = "#{height + 60}px"
-                        step++
-                        # Prevent infinite loop on onresize event
-                        if checkResize and step > 10
-
-                            doc.body.removeEventListener 'load', loadContent
-                            frame.contentWindow?.removeEventListener 'resize'
-
-                    updateHeight()
-                    # some browsers don't fire event when remote fonts are loaded
-                    # so we need to wait a little and check the frame height again
-                    setTimeout updateHeight, 1000
-
-                    # Update frame height on load
-                    doc.body.onload = updateHeight
-
-                    # disabled for now
-                    if checkResize
-                        frame.contentWindow.onresize = updateHeight
-                        window.onresize = updateHeight
-                        frame.contentWindow?.addEventListener 'resize', updateHeight, true
-                else
-                    # try to display text only
-                    @props.displayHTML false
-
-            if type is 'mount' and doc.readyState isnt 'complete'
-                frame.addEventListener 'load', loadContent
-            else
-                loadContent()
-        else
-            ApiUtils.customEvent "MESSAGE_LOADED", @props.messageID
-
-
-    componentDidMount: ->
-        @_initFrame('mount')
-
-
-    componentDidUpdate: ->
-        @_initFrame('update')

--- a/client/app/components/message-list-body.coffee
+++ b/client/app/components/message-list-body.coffee
@@ -14,23 +14,25 @@ RouterGetter = require '../getters/router'
 module.exports = MessageListBody = React.createClass
     displayName: 'MessageListBody'
 
+
+    renderItem: (message) ->
+        messageID = message.get 'id'
+        conversationID = message.get 'conversationID'
+        MessageItem
+            key: "conversation-#{messageID}"
+            message: message
+            mailboxID: @props.mailboxID
+            conversationLengths: RouterGetter.getConversationLength {conversationID}
+            isCompact: SettingsStore.get('listStyle') is 'compact'
+            isSelected: -1 < @props.selection?.indexOf messageID
+            isActive: RouterGetter.isCurrentConversation conversationID
+            login: RouterGetter.getLogin()
+            displayConversations: @props.displayConversations
+            tags:  RouterGetter.getTags message
+
+
     render: ->
-        ul className: 'list-unstyled', ref: 'messageList',
-            @props.messages
-                .mapEntries ([key, message]) =>
-                    messageID = message.get 'id'
-                    conversationID = message.get 'conversationID'
-                    ["message-#{key}", MessageItem
-                        key: 'conversation-' + conversationID
-                        ref: 'messageItem'
-                        message: message
-                        mailboxID: @props.mailboxID
-                        conversationLengths: RouterGetter.getConversationLength {conversationID}
-                        isCompact: SettingsStore.get('listStyle') is 'compact'
-                        isSelected: -1 < @props.selection?.indexOf messageID
-                        isActive: RouterGetter.isCurrentConversation conversationID
-                        login: RouterGetter.getLogin()
-                        displayConversations: @props.displayConversations
-                        tags:  RouterGetter.getTags message
-                    ]
-                .toArray()
+        ul
+            className: 'list-unstyled'
+            ref: 'messageList',
+                @props.messages.map(@renderItem).toArray()

--- a/client/app/components/message-list-item.coffee
+++ b/client/app/components/message-list-item.coffee
@@ -104,7 +104,7 @@ module.exports = MessageItem = React.createClass
         LayoutActionCreator.updateSelection {id, value}
 
     onMessageClick: (event) ->
-        RouterActionCreator.navigate
+        RouterActionCreator.gotoMessage
             messageID: @props.message.get 'id'
 
     onDragStart: (event) ->
@@ -114,8 +114,9 @@ module.exports = MessageItem = React.createClass
         LayoutActionCreator.updateSelection {id, value}
 
     onMessageClick: (event) ->
-        RouterActionCreator.navigate
+        RouterActionCreator.gotoMessage
             messageID: @props.message.get 'id'
+            mailboxID: @props.message.get 'mailboxID'
 
     getParticipants: (message) ->
         from = message.get 'from'

--- a/client/app/components/message-list.coffee
+++ b/client/app/components/message-list.coffee
@@ -58,7 +58,7 @@ module.exports = MessageList = React.createClass
                 isAllSelected: @state.isAllSelected
 
             # Message List
-            unless @props.messages.size
+            unless @props.messages?.size
                 p
                     className: 'list-empty'
                     ref: 'listEmpty'

--- a/client/app/components/message-list.coffee
+++ b/client/app/components/message-list.coffee
@@ -85,7 +85,7 @@ module.exports = MessageList = React.createClass
                         p ref: 'listEnd', t 'list end'
 
     loadMoreMessage: ->
-        RouterActionCreator.getNextPage()
+        RouterActionCreator.gotoNextPage()
 
     _initScroll: ->
         if not (scrollable = ReactDOM.findDOMNode @refs.scrollable) or scrollable.scrollTop

--- a/client/app/components/message.coffee
+++ b/client/app/components/message.coffee
@@ -29,15 +29,8 @@ RGXP_PROTOCOL = /:\/\//
 module.exports = React.createClass
     displayName: 'Message'
 
-    propTypes:
-        active                 : React.PropTypes.bool
-        key                    : React.PropTypes.string.isRequired
-        message                : React.PropTypes.object.isRequired
-        selectedMailboxID      : React.PropTypes.string.isRequired
-        useIntents             : React.PropTypes.bool.isRequired
-
     getInitialState: ->
-        return @getStateFromStores()
+        @getStateFromStores()
 
     componentWillReceiveProps: ->
         @setState @getStateFromStores()

--- a/client/app/components/message.coffee
+++ b/client/app/components/message.coffee
@@ -244,8 +244,9 @@ module.exports = React.createClass
         event.stopPropagation()
 
         success = =>
-            # Then remove message
-            MessageActionCreator.delete messageID: @props.message.get 'id'
+            messageID = @props.message.get 'id'
+            accountID = @props.message.get 'accountID'
+            MessageActionCreator.delete {messageID, accountID}
 
         unless @props.confirmDelete
             success()

--- a/client/app/components/message.coffee
+++ b/client/app/components/message.coffee
@@ -126,7 +126,9 @@ module.exports = React.createClass
         @props.message.get('flags').indexOf(MessageFlags.SEEN) is -1
 
     onHeaderClicked: ->
-        RouterActionCreator.navigate {url} if (url = @props.url)?
+        messageID = @props.message.get 'id'
+        mailboxID = @props.message.get 'mailboxID'
+        RouterActionCreator.gotoMessage {messageID, mailboxID}
 
     render: ->
         message  = @props.message

--- a/client/app/components/message.coffee
+++ b/client/app/components/message.coffee
@@ -4,7 +4,6 @@ classNames = require 'classnames'
 {markdown} = require 'markdown'
 toMarkdown = require 'to-markdown'
 
-React     = require 'react'
 {
     div, article, header, footer, ul, li, span, i, p, a, button, pre,
     iframe, textarea
@@ -28,19 +27,6 @@ RGXP_PROTOCOL = /:\/\//
 
 module.exports = React.createClass
     displayName: 'Message'
-
-    getInitialState: ->
-        @getStateFromStores()
-
-    componentWillReceiveProps: ->
-        @setState @getStateFromStores()
-
-    getStateFromStores: ->
-        # FIXME : le toggle sur
-        # displayHTML et displayImages va casser
-        return {
-            prepared: @prepareMessage()
-        }
 
     prepareMessage: ->
         # display full headers
@@ -96,19 +82,6 @@ module.exports = React.createClass
             isDeleted   : mailboxes[trash]?
         }
 
-    componentWillUnMount: ->
-        @_markRead()
-
-    _markRead: ->
-        messageID = @props.message?.get('id')
-        console.log 'MARK_AS_READ', messageID
-        # # Only mark as read current active message if unseen
-        # flags = message.get('flags').slice()
-        # if flags.indexOf(MessageFlags.SEEN) is -1
-        #     setTimeout ->
-        #         MessageActionCreator.mark {messageID}, MessageFlags.SEEN
-        #     , 1
-
     prepareHTML: (html) ->
         displayHTML = true
         parser = new DOMParser()
@@ -157,12 +130,11 @@ module.exports = React.createClass
 
     render: ->
         message  = @props.message
-        prepared = @state.prepared
+        prepared = @prepareMessage()
 
         if @props.displayHTML and prepared.html?
             {displayHTML, images, html} = @prepareHTML prepared.html
-            imagesWarning = images.length > 0 and
-                            not @props.displayImages
+            imagesWarning = images.length > 0 and not @props.displayImages
         else
             displayHTML = false
             imagesWarning = false
@@ -180,6 +152,7 @@ module.exports = React.createClass
             key: @props.key,
             'data-message-active': @props.active
             'data-id': @props.message.get('id'),
+
                 header onClick: @onHeaderClicked,
                     MessageHeader
                         message: @props.message
@@ -201,8 +174,8 @@ module.exports = React.createClass
 
                     MessageContent
                         ref: 'messageContent'
-                        messageID: message.get 'id'
-                        displayHTML: displayHTML
+                        messageID: @props.message.get 'id'
+                        displayHTML: @props.displayHTML
                         html: html
                         text: prepared.text
                         rich: prepared.rich
@@ -229,7 +202,6 @@ module.exports = React.createClass
             onConversationMark   : @onConversationMark
             onConversationMove   : @onConversationMove
             ref                  : 'toolbarMessage'
-
 
 
     onDelete: (event) ->

--- a/client/app/components/search_bar.coffee
+++ b/client/app/components/search_bar.coffee
@@ -5,7 +5,7 @@ React = require 'react'
 SearchInput = React.createFactory require './search_input'
 AccountPicker = React.createFactory require './account_picker'
 
-AccountStore = require '../stores/account_store'
+RouterGetter = require '../getters/router'
 SearchStore = require '../stores/search_store'
 
 RouterActionCreator = require '../actions/router_action_creator'
@@ -61,7 +61,7 @@ module.exports = GlobalSearchBar = React.createClass
             @setState {accountID}
 
     getStateFromStores: ->
-        accounts = AccountStore.getAll()
+        accounts = RouterGetter.getAccounts()
         .map (account) -> account.get 'label'
         .toOrderedMap()
         .set 'all', t 'search all accounts'

--- a/client/app/components/search_bar.coffee
+++ b/client/app/components/search_bar.coffee
@@ -9,7 +9,6 @@ RouterGetter = require '../getters/router'
 SearchStore = require '../stores/search_store'
 
 RouterActionCreator = require '../actions/router_action_creator'
-{MessageActions, SearchActions} = require '../constants/app_constants'
 
 module.exports = GlobalSearchBar = React.createClass
     displayName: 'GlobalSearchBar'
@@ -42,21 +41,16 @@ module.exports = GlobalSearchBar = React.createClass
                 onSubmit: @onSearchTriggered
 
     onSearchTriggered: (newvalue) ->
-        unless _.isEmpty newvalue
-            RouterActionCreator.navigate
-                action: SearchActions.SHOW_ALL
-                value: newvalue
-            return
-
-        @setState search: ''
-        RouterActionCreator.navigate
-            action: MessageActions.SHOW_ALL
+        unless _.isEmpty (query = newvalue)
+            RouterActionCreator.searchAll
+                value: {query}
+        else
+            RouterActionCreator.showMessageList()
 
     onAccountChanged: (accountID) ->
-        if @state.search isnt ''
-            RouterActionCreator.navigate
-                action: SearchActions.SHOW_ALL
-                value: @state.search
+        if (query = @state.search) isnt ''
+            RouterActionCreator.searchAll
+                value: {query}
         else
             @setState {accountID}
 
@@ -66,7 +60,7 @@ module.exports = GlobalSearchBar = React.createClass
         .toOrderedMap()
         .set 'all', t 'search all accounts'
 
-        accountID = AccountStore.getAccountID() or 'all'
-        search = SearchStore.getCurrentSearch()
+        accountID = RouterGetter.getAccountID() or 'all'
+        search = RouterGetter.getSearch()
 
         return {accounts, search, accountID}

--- a/client/app/components/toolbar_conversation.coffee
+++ b/client/app/components/toolbar_conversation.coffee
@@ -21,7 +21,6 @@ module.exports = React.createClass
 
     render: ->
         nav className: 'toolbar toolbar-conversation btn-toolbar',
-
             ToolboxActions
                 key                  : 'ToolboxActions-' + @props.conversationID
                 mode                 : 'conversation'
@@ -31,18 +30,14 @@ module.exports = React.createClass
                 onConversationMove   : @onMove
 
     onDelete: ->
-        # Remove conversation
         conversationID = @props.conversationID
-
         MessageActionCreator.delete {conversationID}
 
-        # Select previous conversation
-        RouterActionCreator.navigate action: 'conversation.previous'
 
-    # FIXME : this should be in message_action_creator
     onMark: (flag) ->
         conversationID = @props.conversationID
         MessageActionCreator.mark {conversationID}, flag
+
 
     onMove: (to) ->
         conversationID = @props.conversationID

--- a/client/app/components/toolbar_messageslist_actions.coffee
+++ b/client/app/components/toolbar_messageslist_actions.coffee
@@ -37,15 +37,15 @@ module.exports = ActionsToolbarMessagesList = React.createClass
         messageIDs = @props.selection
         MessageActionCreator.delete {messageIDs}
 
+
     onMove: (to) ->
         from = @props.mailboxID
-        MessageActionCreator.move options, from, to, =>
-            if options.count > 0 and @props.messages.size > 0
-                firstMessageID = @props.messages.first().get('id')
-                MessageActionCreator.setCurrent firstMessageID, true
+        MessageActionCreator.move options, from, to
+
 
     onMark: (flag) ->
         MessageActionCreator.mark options, flag
+
 
     onConversationDelete: ->
         @onDelete true

--- a/client/app/getters/icon.coffee
+++ b/client/app/getters/icon.coffee
@@ -2,18 +2,18 @@ _ = require 'lodash'
 
 {SpecialBoxIcons} = require '../constants/app_constants'
 
-AccountStore = require '../stores/account_store'
+RouterStore = require '../stores/router_store'
 
 class IconGetter
 
     getMailboxIcon: (params={}) ->
         {account, mailboxID, type} = params
-        mailboxID ?= AccountStore.getMailboxID()
+        mailboxID ?= RouterStore.getMailboxID()
 
         if (value = SpecialBoxIcons[type])
             return {type, value}
 
-        account ?= AccountStore.getSelected()
+        account ?= RouterStore.getAccount()
         for type, value of SpecialBoxIcons
             if mailboxID is account?.get type
                 return {type, value}

--- a/client/app/getters/router.coffee
+++ b/client/app/getters/router.coffee
@@ -41,11 +41,10 @@ class RouteGetter
             ]
         action in editables
 
-    getQueryParams: ->
-        RouterStore.getQueryParams()
 
     getFilter: ->
         RouterStore.getFilter()
+
 
     getSearch: ->
         SearchStore.getCurrentSearch()
@@ -144,15 +143,5 @@ class RouteGetter
             return t 'no filter message'
         return  t 'list empty'
 
-    # Uniq Key from URL params
-    #
-    # return a {string}
-    getKey: (str = '') ->
-        if (filter = RouterStore.getQueryParams())
-            keys = _.compact ['before', 'after'].map (key) ->
-                filter[key] if filter[key] isnt '-'
-            keys.unshift str unless _.isEmpty str
-            return keys.join('-')
-        return str
 
 module.exports = new RouteGetter()

--- a/client/app/getters/router.coffee
+++ b/client/app/getters/router.coffee
@@ -14,7 +14,7 @@ _ = require 'lodash'
 class RouteGetter
 
     hasNextPage: ->
-        not MessageStore.isAllLoaded()
+        not RouterStore.isAllLoaded()
 
     isCurrentURL: (url) ->
         isServer = false
@@ -62,7 +62,7 @@ class RouteGetter
         RefreshesStore.getRefreshing().get accountID
 
     getSelectedTab: ->
-        AccountStore.getSelectedTab()
+        RouterStore.getSelectedTab()
 
     getModal: ->
         RouterStore.getModalParams()
@@ -75,8 +75,9 @@ class RouteGetter
         mailboxID ?= @getMailboxID()
         return null unless mailboxID
 
-        messages = MessageStore.getMessagesList mailboxID
+        messages = RouterStore.getMessagesList mailboxID
 
+        #TODO : move this into Router_store
         # We dont filter for type from and dest because it is
         # complicated by collation and name vs address.
         unless _.isEmpty (filter = @getFilter()).flags
@@ -90,7 +91,7 @@ class RouteGetter
                 return true
 
         # FIXME : use params ASC et DESC into URL
-        messages.sort sortByDate filter.order
+        messages?.sort sortByDate filter.order
 
     getMessage: (messageID) ->
         MessageStore.getByID messageID
@@ -103,41 +104,41 @@ class RouteGetter
         conversation?.toArray()
 
     getCurrentMessageID: ->
-        MessageStore.getCurrentID()
+        RouterStore.getMessageID()
 
     getCurrentMessage: ->
-        MessageStore.getByID MessageStore.getCurrentID()
+        MessageStore.getByID RouterStore.getMessageID()
 
     isCurrentConversation: (conversationID) ->
         conversationID is @getCurrentMessage()?.get 'conversationID'
 
     getMailbox: (mailboxID) ->
-        AccountStore.getMailbox mailboxID
+        RouterStore.getMailbox mailboxID
 
     getCurrentMailbox: ->
-        AccountStore.getMailbox()
+        RouterStore.getMailbox()
 
     getInbox: (accountID) ->
-        AccountStore.getAllMailboxes(accountID)?.find (mailbox) ->
+        RouterStore.getAllMailboxes(accountID)?.find (mailbox) ->
             'INBOX' is mailbox.get 'label'
 
     getAccounts: ->
         AccountStore.getAll()
 
     getAccountSignature: ->
-        AccountStore.getSelected()?.get 'signature'
+        RouterStore.getAccount()?.get 'signature'
 
     getAccountID: ->
-        AccountStore.getAccountID()
+        RouterStore.getAccountID()
 
     getMailboxID: ->
-        AccountStore.getMailboxID()
+        RouterStore.getMailboxID()
 
     getLogin: ->
         @getCurrentMailbox()?.get 'login'
 
     getMailboxes: ->
-        AccountStore.getAllMailboxes()
+        RouterStore.getAllMailboxes()
 
     getTags: (message) ->
         mailboxID = @getMailboxID()

--- a/client/app/getters/router.coffee
+++ b/client/app/getters/router.coffee
@@ -13,7 +13,7 @@ _ = require 'lodash'
 class RouteGetter
 
     hasNextPage: ->
-        not RouterStore.isAllLoaded()
+        RouterStore.hasNextPage()
 
     isCurrentURL: (url) ->
         isServer = false
@@ -99,8 +99,7 @@ class RouteGetter
         RouterStore.getMailbox()
 
     getInbox: (accountID) ->
-        RouterStore.getAllMailboxes(accountID)?.find (mailbox) ->
-            'INBOX' is mailbox.get 'label'
+        RouterStore.getInbox accountID
 
     getAccounts: ->
         AccountStore.getAll()

--- a/client/app/getters/router.coffee
+++ b/client/app/getters/router.coffee
@@ -6,8 +6,7 @@ RefreshesStore = require '../stores/refreshes_store'
 RouterStore = require '../stores/router_store'
 
 Immutable = require 'immutable'
-{sortByDate} = require '../utils/misc'
-{MessageFilter, MessageActions, MessageFlags, MailboxFlags} = require '../constants/app_constants'
+{MessageActions, MailboxFlags} = require '../constants/app_constants'
 
 _ = require 'lodash'
 
@@ -67,34 +66,15 @@ class RouteGetter
     getModal: ->
         RouterStore.getModalParams()
 
-    isFlags: (name) ->
-        flags = @getFilter()?.flags or []
-        MessageFilter[name] is flags or MessageFilter[name] in flags
 
     getMessagesList: (mailboxID) ->
         mailboxID ?= @getMailboxID()
-        return null unless mailboxID
+        RouterStore.getMessagesList mailboxID
 
-        messages = RouterStore.getMessagesList mailboxID
-
-        #TODO : move this into Router_store
-        # We dont filter for type from and dest because it is
-        # complicated by collation and name vs address.
-        unless _.isEmpty (filter = @getFilter()).flags
-            messages = messages.filter (message, index) =>
-                if @isFlags 'FLAGGED'
-                    return MessageFlags.FLAGGED in message.get 'flags'
-                if @isFlags 'ATTACH'
-                    return message.get('attachments')?.size > 0
-                if @isFlags 'UNSEEN'
-                    return MessageFlags.SEEN not in message.get 'flags'
-                return true
-
-        # FIXME : use params ASC et DESC into URL
-        messages?.sort sortByDate filter.order
 
     getMessage: (messageID) ->
         MessageStore.getByID messageID
+
 
     getConversationLength: ({messageID, conversationID}) ->
         MessageStore.getConversationLength {messageID, conversationID}
@@ -152,12 +132,11 @@ class RouteGetter
                     return mailbox?.get 'label'
 
     getEmptyMessage: ->
-        filter = @getFilter()
-        if @isFlags 'UNSEEN', filter.flags
+        if RouterStore.isFlags 'UNSEEN'
             return  t 'no unseen message'
-        if @isFlags 'FLAGGED', filter.flags
+        if RouterStore.isFlags 'FLAGGED'
             return  t 'no flagged message'
-        if @isFlags 'ATTACH', filter.flags
+        if RouterStore.isFlags 'ATTACH'
             return t 'no filter message'
         return  t 'list empty'
 

--- a/client/app/getters/router.coffee
+++ b/client/app/getters/router.coffee
@@ -15,10 +15,10 @@ class RouteGetter
     hasNextPage: ->
         RouterStore.hasNextPage()
 
-    isCurrentURL: (url) ->
+    isCurrentURL: (mailboxURL) ->
         isServer = false
         currentURL = RouterStore.getCurrentURL {isServer}
-        currentURL is url
+        0 is currentURL.indexOf mailboxURL
 
     getURL: (params) ->
         RouterStore.getURL params

--- a/client/app/getters/router.coffee
+++ b/client/app/getters/router.coffee
@@ -18,7 +18,13 @@ class RouteGetter
     isCurrentURL: (mailboxURL) ->
         isServer = false
         currentURL = RouterStore.getCurrentURL {isServer}
-        0 is currentURL.indexOf mailboxURL
+
+        current = currentURL.split('?')
+        mailbox = mailboxURL.split('?')
+        isSameMailbox = 0 is current[0].indexOf mailbox[0]
+        isSameQuery = current[1] is mailbox[1]
+
+        isSameMailbox and isSameQuery
 
     getURL: (params) ->
         RouterStore.getURL params

--- a/client/app/getters/router.coffee
+++ b/client/app/getters/router.coffee
@@ -73,15 +73,15 @@ class RouteGetter
 
 
     getMessage: (messageID) ->
+        messageID ?= RouterStore.getMessageID()
         MessageStore.getByID messageID
 
 
     getConversationLength: ({messageID, conversationID}) ->
-        MessageStore.getConversationLength {messageID, conversationID}
+        RouterStore.getConversationLength {messageID, conversationID}
 
     getConversation: (messageID) ->
-        conversation = MessageStore.getConversation messageID
-        conversation?.toArray()
+        RouterStore.getConversation(messageID)
 
     getCurrentMessageID: ->
         RouterStore.getMessageID()
@@ -99,7 +99,12 @@ class RouteGetter
         RouterStore.getMailbox()
 
     getInbox: (accountID) ->
+        accountID ?= @getAccountID()
         RouterStore.getInbox accountID
+
+    getTrashMailbox: (accountID) ->
+        accountID ?= @getAccountID()
+        RouterStore.getTrashMailbox accountID
 
     getAccounts: ->
         AccountStore.getAll()

--- a/client/app/router.coffee
+++ b/client/app/router.coffee
@@ -29,7 +29,7 @@ class Router extends Backbone.Router
         'mailbox/:mailboxID/:messageID/reply':     'messageReply'
         'mailbox/:mailboxID/:messageID/reply-all': 'messageReplyAll'
         'mailbox/:mailboxID/:messageID(?:query)':  'messageShow'
-        '':                                        'defaultMailbox'
+        '':                                        'defaultView'
 
 
     initialize: ->
@@ -47,7 +47,7 @@ class Router extends Backbone.Router
         Backbone.history.start()
 
 
-    defaultMailbox: ->
+    defaultView: ->
         url = if (mailboxID = AccountStore.getMailboxID())
         then "mailbox/#{mailboxID}"
         else "account/new"

--- a/client/app/router.coffee
+++ b/client/app/router.coffee
@@ -101,14 +101,17 @@ class Router extends Backbone.Router
 _dispatch = (payload, query) ->
     payload.query = _parseQuery query if query
 
-    # Fetch Messages
-    if payload.action in
-    [MessageActions.SHOW_ALL, MessageActions.SHOW]
-        RouterActionCreator.getCurrentPage payload
-
     AppDispatcher.dispatch
         type: ActionTypes.ROUTE_CHANGE
         value: payload
+
+    # Fetch Messages
+    if payload.action in
+    [MessageActions.SHOW_ALL, MessageActions.SHOW]
+        payload.filter = payload.query
+        delete payload.query
+        RouterActionCreator.getCurrentPage payload
+
 
 
 # Extract params from q queryString to an object that map `key` > `value`.

--- a/client/app/router.coffee
+++ b/client/app/router.coffee
@@ -106,11 +106,8 @@ _dispatch = (payload, query) ->
         value: payload
 
     # Fetch Messages
-    if payload.action in
-    [MessageActions.SHOW_ALL, MessageActions.SHOW]
-        payload.filter = payload.query
-        delete payload.query
-        RouterActionCreator.getCurrentPage payload
+    if payload.action in [MessageActions.SHOW_ALL, MessageActions.SHOW]
+        RouterActionCreator.getCurrentPage()
 
 
 

--- a/client/app/router.coffee
+++ b/client/app/router.coffee
@@ -72,6 +72,7 @@ class Router extends Backbone.Router
     messageShow: (mailboxID, messageID, query) ->
         _dispatch {action: MessageActions.SHOW, mailboxID, messageID}, query
 
+
     messageEdit: (mailboxID, messageID) ->
         _dispatch {action: MessageActions.EDIT, mailboxID, messageID}
 

--- a/client/app/router.coffee
+++ b/client/app/router.coffee
@@ -2,7 +2,9 @@ Backbone = require 'backbone'
 React    = require 'react'
 ReactDOM = require 'react-dom'
 
-AccountStore = require './stores/account_store'
+# TODO : Call getter instead ?
+RouterStore = require './stores/router_store'
+RouterActionCreator = require './actions/router_action_creator'
 
 AppDispatcher = require './libs/flux/dispatcher/dispatcher'
 
@@ -98,6 +100,12 @@ class Router extends Backbone.Router
 # Dispatch payload with extracted query if available
 _dispatch = (payload, query) ->
     payload.query = _parseQuery query if query
+
+    # Fetch Messages
+    if payload.action in
+    [MessageActions.SHOW_ALL, MessageActions.SHOW]
+        RouterActionCreator.getCurrentPage payload
+
     AppDispatcher.dispatch
         type: ActionTypes.ROUTE_CHANGE
         value: payload

--- a/client/app/router.coffee
+++ b/client/app/router.coffee
@@ -2,7 +2,6 @@ Backbone = require 'backbone'
 React    = require 'react'
 ReactDOM = require 'react-dom'
 
-# TODO : Call getter instead ?
 RouterStore = require './stores/router_store'
 RouterActionCreator = require './actions/router_action_creator'
 
@@ -50,7 +49,7 @@ class Router extends Backbone.Router
 
 
     defaultView: ->
-        url = if (mailboxID = AccountStore.getMailboxID())
+        url = if (mailboxID = RouterStore.getMailboxID())
         then "mailbox/#{mailboxID}"
         else "account/new"
 

--- a/client/app/router.coffee
+++ b/client/app/router.coffee
@@ -108,7 +108,7 @@ _dispatch = (payload, query) ->
 
     # Fetch Messages
     if payload.action in [MessageActions.SHOW_ALL, MessageActions.SHOW]
-        RouterActionCreator.getCurrentPage()
+        RouterActionCreator.gotoCurrentPage()
 
 
 

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -71,7 +71,7 @@ class AccountStore extends Store
     _setMailbox = (data) ->
         # on account creation, sometime socket send mailboxes updates
         # before the account has been saved locally
-        return true unless (account = _accounts.get _accountID)?.size
+        return true unless (account = _accounts?.get _accountID)?.size
 
         mailboxID = data.id
         mailboxes = account.get('mailboxes')
@@ -86,7 +86,7 @@ class AccountStore extends Store
             # FIXME : is attaching mailboxes to account useless?
             account = account.set 'mailboxes', mailboxes
 
-            _accounts = _accounts.set _accountID, account
+            _accounts = _accounts?.set _accountID, account
 
 
     _mailboxSort = (mb1, mb2) ->
@@ -109,7 +109,7 @@ class AccountStore extends Store
     _updateAccount = (rawAccount) ->
         account = AccountTranslator.toImmutable rawAccount
         accountID = account.get 'id'
-        _accounts = _accounts.set accountID, account
+        _accounts = _accounts?.set accountID, account
 
 
     ###
@@ -182,7 +182,7 @@ class AccountStore extends Store
             @emit 'change'
 
         handle ActionTypes.REMOVE_ACCOUNT_SUCCESS, (accountID) ->
-            _accounts = _accounts.delete accountID
+            _accounts = _accounts?.delete accountID
             _setCurrentAccount()
             @emit 'change'
 
@@ -207,14 +207,14 @@ class AccountStore extends Store
 
 
     getByLabel: (label) ->
-        _accounts.find (account) -> account.get('label') is label
+        _accounts?.find (account) -> account.get('label') is label
 
 
     getDefault: (mailboxID) ->
         if mailboxID
-            return _accounts.find (account) ->
+            return _accounts?.find (account) ->
                 account.get('mailboxes').get(mailboxID)
-        return _accounts.first()
+        return _accounts?.first()
 
 
     getAccountID: ->
@@ -233,7 +233,7 @@ class AccountStore extends Store
 
     getAllMailboxes: (accountID) ->
         accountID ?= @getAccountID()
-        return _accounts.get accountID
+        return _accounts?.get accountID
             .get 'mailboxes'
             .sort _mailboxSort
 

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -1,7 +1,7 @@
 _         = require 'underscore'
 Immutable = require 'immutable'
 XHRUtils = require '../utils/xhr_utils'
-AppDispatcher = require '../app_dispatcher'
+AppDispatcher = require '../libs/flux/dispatcher/dispatcher'
 
 Store = require '../libs/flux/store/store'
 

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -71,21 +71,21 @@ class AccountStore extends Store
 
     _updateMailbox = (data) ->
         mailboxID = data.id
-        account = _getByMailbox mailboxID
-        if (accountID = account?.get 'id')
-            mailboxes = account.get 'mailboxes'
-            mailbox = mailboxes?.get(mailboxID) or Immutable.Map()
+        return unless (account = _getByMailbox mailboxID)?.size
 
-            for field, value of data
-                mailbox = mailbox.set field, value
+        mailboxes = account.get('mailboxes')
+        mailbox = mailboxes.get(mailboxID) or Immutable.Map()
+
+        for field, value of data
+            mailbox = mailbox.set field, value
 
             if mailbox isnt mailboxes.get mailboxID
                 mailboxes = mailboxes.set mailboxID, mailbox
 
-                # FIXME : is attaching mailboxes to account usefull?
-                account = account.set 'mailboxes', mailboxes
+            # FIXME : is attaching mailboxes to account usefull?
+            account = account.set 'mailboxes', mailboxes
 
-                _accounts = _accounts.set accountID, account
+            _accounts = _accounts.set accountID, account
 
 
     _mailboxSort = (mb1, mb2) ->

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -71,21 +71,21 @@ class AccountStore extends Store
 
     _updateMailbox = (data) ->
         mailboxID = data.id
-        return unless (account = _getByMailbox mailboxID)?.size
+        account = _getByMailbox mailboxID
+        if (accountID = account?.get 'id')
+            mailboxes = account.get 'mailboxes'
+            mailbox = mailboxes?.get(mailboxID) or Immutable.Map()
 
-        mailboxes = account.get('mailboxes')
-        mailbox = mailboxes.get(mailboxID) or Immutable.Map()
-
-        for field, value of data
-            mailbox = mailbox.set field, value
+            for field, value of data
+                mailbox = mailbox.set field, value
 
             if mailbox isnt mailboxes.get mailboxID
                 mailboxes = mailboxes.set mailboxID, mailbox
 
-            # FIXME : is attaching mailboxes to account usefull?
-            account = account.set 'mailboxes', mailboxes
+                # FIXME : is attaching mailboxes to account usefull?
+                account = account.set 'mailboxes', mailboxes
 
-            _accounts = _accounts.set accountID, account
+                _accounts = _accounts.set accountID, account
 
 
     _mailboxSort = (mb1, mb2) ->

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -1,11 +1,11 @@
 _         = require 'underscore'
 Immutable = require 'immutable'
+XHRUtils = require '../utils/xhr_utils'
+AppDispatcher = require '../app_dispatcher'
 
 Store = require '../libs/flux/store/store'
 
-RouterGetter = require '../getters/router'
-
-{ActionTypes, AccountActions} = require '../constants/app_constants'
+{ActionTypes} = require '../constants/app_constants'
 
 AccountTranslator = require '../utils/translators/account_translator'
 
@@ -32,15 +32,12 @@ class AccountStore extends Store
 
         .toOrderedMap()
 
-    _accountID = null
-    _mailboxID = null
-
+    # FIXME : move this into ROuter Store
     _newAccountWaiting = false
     _newAccountChecking = false
 
     _serverAccountErrorByField = Immutable.Map()
 
-    _tab = null
 
     _clearError = ->
         _serverAccountErrorByField = Immutable.Map()
@@ -67,26 +64,28 @@ class AccountStore extends Store
         else
             _serverAccountErrorByField = Immutable.Map "unknown": error
 
+    _getByMailbox = (mailboxID) ->
+        _accounts?.find (account) ->
+            account.get('mailboxes').get mailboxID
 
-    _setMailbox = (data) ->
-        # on account creation, sometime socket send mailboxes updates
-        # before the account has been saved locally
-        return true unless (account = _accounts?.get _accountID)?.size
 
+    _updateMailbox = (data) ->
         mailboxID = data.id
-        mailboxes = account.get('mailboxes')
+        account = _getByMailbox mailboxID
+        if (accountID = account?.get 'id')
+            mailboxes = account.get 'mailboxes'
+            mailbox = mailboxes?.get(mailboxID) or Immutable.Map()
 
-        mailbox = mailboxes.get(mailboxID) or Immutable.Map()
-        for field, value of data
-            mailbox = mailbox.set field, value
+            for field, value of data
+                mailbox = mailbox.set field, value
 
-        if mailbox isnt mailboxes.get mailboxID
-            mailboxes = mailboxes.set mailboxID, mailbox
+            if mailbox isnt mailboxes.get mailboxID
+                mailboxes = mailboxes.set mailboxID, mailbox
 
-            # FIXME : is attaching mailboxes to account useless?
-            account = account.set 'mailboxes', mailboxes
+                # FIXME : is attaching mailboxes to account usefull?
+                account = account.set 'mailboxes', mailboxes
 
-            _accounts = _accounts?.set _accountID, account
+                _accounts = _accounts.set accountID, account
 
 
     _mailboxSort = (mb1, mb2) ->
@@ -100,27 +99,34 @@ class AccountStore extends Store
             else return 0
 
 
-    _setCurrentAccount = (accountID, mailboxID, tab="mailboxes") ->
-        _accountID = accountID
-        _mailboxID = mailboxID
-        _tab = tab
-
-
     _updateAccount = (rawAccount) ->
         account = AccountTranslator.toImmutable rawAccount
         accountID = account.get 'id'
         _accounts = _accounts?.set accountID, account
 
 
+    # Refresh Emails from Server
+    # This is a read data pattern
+    # ActionCreator is a write data pattern
+    _refreshMailbox = (mailboxID) ->
+        deep = true
+        XHRUtils.refreshMailbox mailboxID, {deep}, (error, updated) ->
+            if error?
+                AppDispatcher.dispatch
+                    type: ActionTypes.REFRESH_FAILURE
+                    value: {mailboxID, error}
+            else
+                AppDispatcher.dispatch
+                    type: ActionTypes.REFRESH_SUCCESS
+                    value: {mailboxID, updated}
+
+
     ###
         Defines here the action handlers.
     ###
     __bindHandlers: (handle) ->
-
-        handle ActionTypes.ROUTE_CHANGE, ({accountID, mailboxID, action, tab}) ->
-            accountID ?= @getDefault(mailboxID)?.get('id') if mailboxID
-            _setCurrentAccount accountID, mailboxID, tab
-
+        handle ActionTypes.ROUTE_CHANGE, ({mailboxID}) ->
+            _refreshMailbox mailboxID
             @emit 'change'
 
         handle ActionTypes.ADD_ACCOUNT_REQUEST, ({value}) ->
@@ -182,12 +188,10 @@ class AccountStore extends Store
             @emit 'change'
 
         handle ActionTypes.REMOVE_ACCOUNT_SUCCESS, (accountID) ->
-            _accounts = _accounts?.delete accountID
-            _setCurrentAccount()
             @emit 'change'
 
         handle ActionTypes.RECEIVE_MAILBOX_UPDATE, (mailbox) ->
-            _setMailbox mailbox
+            _updateMailbox mailbox
             @emit 'change'
 
 
@@ -195,54 +199,36 @@ class AccountStore extends Store
         Public API
     ###
     getAll: ->
-        return _accounts
-
-
-    getSelectedTab: ->
-        return _tab
+        _accounts
 
 
     getByID: (accountID) ->
-        return _accounts?.get accountID
-
-
-    getByLabel: (label) ->
-        _accounts?.find (account) -> account.get('label') is label
+        _accounts?.get accountID
 
 
     getDefault: (mailboxID) ->
         if mailboxID
-            return _accounts?.find (account) ->
-                account.get('mailboxes').get(mailboxID)
-        return _accounts?.first()
+            return @getByMailbox mailboxID
+        else
+            return @getAll().first()
 
 
-    getAccountID: ->
-        return @getDefault()?.get 'id' unless _accountID
-        return _accountID
+    getByMailbox: (mailboxID) ->
+        _getByMailbox mailboxID
 
 
-    getMailboxID: ->
-        return @getDefault()?.get 'inboxMailbox' unless _mailboxID
-        return _mailboxID
-
-
-    getSelected: ->
-        return _accounts?.get _accountID
+    getByLabel: (label) ->
+        _accounts?.find (account) ->
+            account.get('label') is label
 
 
     getAllMailboxes: (accountID) ->
-        accountID ?= @getAccountID()
-        return _accounts?.get accountID
+        _accounts?.get accountID
             .get 'mailboxes'
             .sort _mailboxSort
 
 
-    getMailbox: (mailboxID) ->
-        mailboxID ?= _mailboxID
-        return @getAllMailboxes()?.get mailboxID
-
-
+    # FIXME : move this into ROuterStore
     getErrors: -> _serverAccountErrorByField
     getRawErrors: -> _serverAccountErrorByField.get('unknown')
     getAlertErrorMessage: ->
@@ -256,5 +242,4 @@ class AccountStore extends Store
     isChecking: -> return _newAccountChecking
 
 
-
-module.exports = _self = new AccountStore()
+module.exports = new AccountStore()

--- a/client/app/stores/layout_store.coffee
+++ b/client/app/stores/layout_store.coffee
@@ -4,8 +4,6 @@ AppDispatcher = require '../libs/flux/dispatcher/dispatcher'
 
 Store = require '../libs/flux/store/store'
 
-AccountStore = require './account_store'
-
 {ActionTypes, Dispositions} = require '../constants/app_constants'
 
 class LayoutStore extends Store
@@ -18,8 +16,6 @@ class LayoutStore extends Store
 
     # TODO: Use a constant for default value?
     _previewSize = 60
-
-    _focus = null
 
     _shown = true
 
@@ -50,8 +46,6 @@ class LayoutStore extends Store
                 _previewSize = 50
             @emit 'change'
 
-        handle ActionTypes.FOCUS, (path) ->
-            _focus = path
 
         handle ActionTypes.REFRESH, ->
             @emit 'change'
@@ -76,16 +70,13 @@ class LayoutStore extends Store
     getDisposition: ->
         return _disposition
 
+
     getListModeCompact: ->
         return _listModeCompact
 
 
     getPreviewSize: ->
         return _previewSize
-
-
-    getFocus: ->
-        return _focus
 
 
     isShown: ->

--- a/client/app/stores/message_store.coffee
+++ b/client/app/stores/message_store.coffee
@@ -5,15 +5,11 @@ XHRUtils = require '../utils/xhr_utils'
 AppDispatcher = require '../libs/flux/dispatcher/dispatcher'
 
 Store = require '../libs/flux/store/store'
-AccountStore = require './account_store'
-RouterStore = require './router_store'
 
-RouterGetter = require '../getters/router'
 
 {changeRealtimeScope} = require '../utils/realtime_utils'
-{sortByDate} = require '../utils/misc'
 
-{ActionTypes, MessageFlags, MessageActions} = require '../constants/app_constants'
+{ActionTypes, MessageActions} = require '../constants/app_constants'
 
 EPOCH = (new Date(0)).toISOString()
 
@@ -27,17 +23,10 @@ class MessageStore extends Store
     _messages = Immutable.OrderedMap()
     _conversationLength = Immutable.Map()
 
-    _currentMessages = Immutable.OrderedMap()
-
-    _currentID = null
-
     _inFlightByRef = {}
     _inFlightByMessageID = {}
     _undoable = {}
 
-
-    _setCurrentID = (messageID) ->
-        _currentID = messageID
 
     _addInFlight = (request) ->
         _inFlightByRef[request.ref] = request
@@ -74,44 +63,19 @@ class MessageStore extends Store
             .toArray()
         else throw new Error 'Wrong Usage : unrecognized target AS.getMixed'
 
-    isAllLoaded: ->
-        total = AccountStore.getMailbox()?.get('nbTotal')
-        total is _currentMessages?.size
-
-
-    # Refresh Emails from Server
-    # This is a read data pattern
-    # ActionCreator is a write data pattern
-    _refreshMailbox = (params={}) ->
-        {mailboxID} = params
-        mailboxID ?= AccountStore.getMailboxID()
-        deep = true
-
-        XHRUtils.refreshMailbox mailboxID, {deep}, (error, updated) ->
-            if error?
-                AppDispatcher.dispatch
-                    type: ActionTypes.REFRESH_FAILURE
-                    value: {mailboxID, error}
-            else
-                AppDispatcher.dispatch
-                    type: ActionTypes.REFRESH_SUCCESS
-                    value: {mailboxID, updated}
-
 
     # Get Emails from Server
     # This is a read data pattern
     # ActionCreator is a write data pattern
     _fetchMessages = (params={}) ->
-        {messageID, conversationID, action} = params
-        mailboxID = AccountStore.getMailboxID()
-        action ?= MessageActions.SHOW_ALL
-        timestamp = Date.now()
+        {messageID, conversationID, url} = params
 
+        timestamp = Date.now()
         callback = (error, result) ->
             if error?
                 AppDispatcher.dispatch
                     type: ActionTypes.MESSAGE_FETCH_FAILURE
-                    value: {error, mailboxID}
+                    value: {error, url}
             else
                 # This prevent to override local updates
                 # with older ones from server
@@ -124,31 +88,25 @@ class MessageStore extends Store
                     for conversationID, length of conversationLength
                         _saveConversationLength conversationID, length
 
-                # Message should belong to the result
-                # If not : go fetch next messages
-                if not _self.isAllLoaded() and messageID and
-                        not _messages?.get messageID
-                    action = MessageActions.PAGE_NEXT
-                    AppDispatcher.dispatch
-                        type: ActionTypes.MESSAGE_FETCH_REQUEST
-                        value: {action, messageID, mailboxID}
-                else
-                    AppDispatcher.dispatch
-                        type: ActionTypes.MESSAGE_FETCH_SUCCESS
-                        value: {action, messages, messageID, mailboxID}
+                # # Message should belong to the result
+                # # If not : go fetch next messages
+                # # TODO : ajouter un param ici pour autorise le fetch ou pas
+                # if not _self.isAllLoaded() and messageID and
+                #         not _messages?.get messageID
+                #     action = MessageActions.PAGE_NEXT
+                #     AppDispatcher.dispatch
+                #         type: ActionTypes.MESSAGE_FETCH_REQUEST
+                #         value: {messageID}
+                # else
+                AppDispatcher.dispatch
+                    type: ActionTypes.MESSAGE_FETCH_SUCCESS
+                    value: {messages, messageID}
 
-        if action is MessageActions.PAGE_NEXT
-            action = MessageActions.SHOW_ALL
-            messages = _messages
-            url = RouterStore.getNextURL {action, messages, messageID}
+        if url
             XHRUtils.fetchMessagesByFolder url, callback
-
-        else if action is MessageActions.SHOW_ALL
-            url = RouterStore.getCurrentURL {action, mailboxID}
-            XHRUtils.fetchMessagesByFolder url, callback
-
         else
             XHRUtils.fetchConversation conversationID, callback
+
 
     _saveMessage = (message, timestamp) ->
         oldmsg = _messages.get message.id
@@ -195,20 +153,6 @@ class MessageStore extends Store
     ###
     __bindHandlers: (handle) ->
 
-        handle ActionTypes.ROUTE_CHANGE, (payload) ->
-            {action, mailboxID, messageID} = payload
-
-            # Update currentMessageID
-            _setCurrentID messageID
-
-            # Get messageList for 1rst panel
-            if action in [MessageActions.SHOW_ALL, MessageActions.SHOW]
-                _refreshMailbox {mailboxID}
-                _fetchMessages {action, mailboxID, messageID}
-
-            @emit 'change'
-
-
         handle ActionTypes.MESSAGE_FETCH_REQUEST, (payload) ->
             _fetchMessages payload
             @emit 'change'
@@ -241,23 +185,6 @@ class MessageStore extends Store
             .toOrderedMap()
             @emit 'change'
 
-        handle ActionTypes.MESSAGE_TRASH_REQUEST, ({target, ref}) ->
-            messages = _getMixed target
-            target.accountID = messages[0].get 'accountID'
-            trashBoxID = AccountStore.getSelected().get 'trashMailbox'
-            _addInFlight {type: 'trash', trashBoxID, messages, ref}
-            @emit 'change'
-
-        handle ActionTypes.MESSAGE_TRASH_SUCCESS, ({target, updated, ref}) ->
-            _undoable[ref] = _removeInFlight ref
-            for message in updated
-                if message._deleted
-                    _deleteMessage message
-                    if (nextMessage = @getNextConversation())?.size
-                        _setCurrentID nextMessage?.get 'id'
-                else
-                    _saveMessage message
-            @emit 'change'
 
         handle ActionTypes.MESSAGE_FLAGS_SUCCESS, ({target, updated, ref}) ->
             _removeInFlight ref
@@ -315,29 +242,15 @@ class MessageStore extends Store
     ###
         Public API
     ###
-    getCurrentID: ->
-        return _currentID
+    getAll: ->
+        _messages
+
 
     getByID: (messageID) ->
-        messageID ?= _currentID
         _messages.get messageID
 
-    _getCurrentConversations = (mailboxID) ->
-        __conv = {}
-        _messages.filter (message) ->
-            conversationID = message.get 'conversationID'
-            __conv[conversationID] = true unless (exist = __conv[conversationID])
-            inMailbox = mailboxID of message.get 'mailboxIDs'
-            return inMailbox and not exist
-        .toList()
-
-    getMessagesList: (mailboxID) ->
-        _currentMessages = _getCurrentConversations(mailboxID)?.toOrderedMap()
-        return _currentMessages
 
     getConversation: (messageID) ->
-        messageID ?= @getCurrentID()
-
         # Get messages from loaded ones
         # Do not fetch if messages isnt loaded yet
         if (conversationID = @getByID(messageID)?.get 'conversationID')
@@ -353,30 +266,13 @@ class MessageStore extends Store
             return conversation
 
 
-    getNextConversation: ->
-        index = _currentMessages.keyOf @getByID()
-        return _currentMessages.get --index
-
-
-    getPreviousConversation: ->
-        index = _currentMessages.keyOf @getByID()
-        return _currentMessages.get ++index
-
-
-    getConversationLength: ({messageID, conversationID}) ->
-        unless conversationID
-            messageID ?= @getCurrentID()
-            if messageID and (message = @getByID messageID)
-                conversationID = message.get 'conversationID'
-
-        if conversationID
-            return _conversationLength.get conversationID
+    getConversationLength: (conversationID) ->
+        _conversationLength?.get conversationID
 
 
     # FIXME : move this into RouterStore/RouterGetter
     getUndoableRequest: (ref) ->
         _undoable[ref]
 
-_self = new MessageStore()
 
-module.exports = _self
+module.exports = new MessageStore()

--- a/client/app/stores/message_store.coffee
+++ b/client/app/stores/message_store.coffee
@@ -69,8 +69,8 @@ class MessageStore extends Store
     # ActionCreator is a write data pattern
     _fetchMessages = (params={}) ->
         {messageID, conversationID, url} = params
-
         timestamp = Date.now()
+
         callback = (error, result) ->
             if error?
                 AppDispatcher.dispatch
@@ -88,16 +88,6 @@ class MessageStore extends Store
                     for conversationID, length of conversationLength
                         _saveConversationLength conversationID, length
 
-                # # Message should belong to the result
-                # # If not : go fetch next messages
-                # # TODO : ajouter un param ici pour autorise le fetch ou pas
-                # if not _self.isAllLoaded() and messageID and
-                #         not _messages?.get messageID
-                #     action = MessageActions.PAGE_NEXT
-                #     AppDispatcher.dispatch
-                #         type: ActionTypes.MESSAGE_FETCH_REQUEST
-                #         value: {messageID}
-                # else
                 AppDispatcher.dispatch
                     type: ActionTypes.MESSAGE_FETCH_SUCCESS
                     value: {messages, messageID}

--- a/client/app/stores/message_store.coffee
+++ b/client/app/stores/message_store.coffee
@@ -90,7 +90,19 @@ class MessageStore extends Store
 
                 AppDispatcher.dispatch
                     type: ActionTypes.MESSAGE_FETCH_SUCCESS
-                    value: {messages, messageID}
+                    value: {action, result, messageID}
+
+                # Message doesnt belong to the result
+                # Go fetch next page
+                if messageID and not _messages?.get messageID
+                    AppDispatcher.dispatch
+                        type: ActionTypes.MESSAGE_FETCH_REQUEST
+                        value: {action, messageID, mailboxID}
+                else
+                    action = MessageActions.PAGE_NEXT
+                    AppDispatcher.handleViewAction
+                        type: ActionTypes.MESSAGE_FETCH_REQUEST
+                        value: {action, messageID}
 
         if url
             XHRUtils.fetchMessagesByFolder url, callback

--- a/client/app/stores/message_store.coffee
+++ b/client/app/stores/message_store.coffee
@@ -67,8 +67,9 @@ class MessageStore extends Store
 
         # Shortcut to know conversationLength
         # withount loading all massages of the conversation
-        for conversationID, length of conversationLength
-            _conversationLength = _conversationLength.set conversationID, length
+        if (conversationLength)
+            for conversationID, length of conversationLength
+                _conversationLength = _conversationLength.set conversationID, length
 
 
     _saveMessage = (message, timestamp) ->

--- a/client/app/stores/message_store.coffee
+++ b/client/app/stores/message_store.coffee
@@ -251,7 +251,6 @@ class MessageStore extends Store
         _conversationLength?.get conversationID
 
 
-    # FIXME : move this into RouterStore/RouterGetter
     getUndoableRequest: (ref) ->
         _undoable[ref]
 

--- a/client/app/stores/message_store.coffee
+++ b/client/app/stores/message_store.coffee
@@ -95,7 +95,7 @@ class MessageStore extends Store
         if url
             XHRUtils.fetchMessagesByFolder url, callback
         else
-            XHRUtils.fetchConversation conversationID, callback
+            XHRUtils.fetchConversation {messageID, conversationID}, callback
 
 
     _saveMessage = (message, timestamp) ->
@@ -235,25 +235,16 @@ class MessageStore extends Store
     getAll: ->
         _messages
 
-
     getByID: (messageID) ->
-        _messages.get messageID
+        _messages.get(messageID)
 
 
-    getConversation: (messageID) ->
-        # Get messages from loaded ones
-        # Do not fetch if messages isnt loaded yet
-        if (conversationID = @getByID(messageID)?.get 'conversationID')
-            conversation = _messages.filter (message) ->
-                conversationID is message.get 'conversationID'
-
-            # If missing messages, get them
-            if conversation?.size isnt @getConversationLength {conversationID}
-                action = MessageActions.SHOW
-                _fetchMessages {messageID, conversationID, action}
-
-            # Return loaded messages
-            return conversation
+    getConversation: (conversationID) ->
+        result = []
+        _messages.filter (message) ->
+            if (conversationID is message.get 'conversationID')
+                result.push message
+        result
 
 
     getConversationLength: (conversationID) ->

--- a/client/app/stores/message_store.coffee
+++ b/client/app/stores/message_store.coffee
@@ -263,6 +263,7 @@ class MessageStore extends Store
         _conversationLength?.get conversationID
 
 
+    # FIXME : move this into RouterStore/RouterGetter
     getUndoableRequest: (ref) ->
         _undoable[ref]
 

--- a/client/app/stores/message_store.coffee
+++ b/client/app/stores/message_store.coffee
@@ -90,19 +90,7 @@ class MessageStore extends Store
 
                 AppDispatcher.dispatch
                     type: ActionTypes.MESSAGE_FETCH_SUCCESS
-                    value: {action, result, messageID}
-
-                # Message doesnt belong to the result
-                # Go fetch next page
-                if messageID and not _messages?.get messageID
-                    AppDispatcher.dispatch
-                        type: ActionTypes.MESSAGE_FETCH_REQUEST
-                        value: {action, messageID, mailboxID}
-                else
-                    action = MessageActions.PAGE_NEXT
-                    AppDispatcher.handleViewAction
-                        type: ActionTypes.MESSAGE_FETCH_REQUEST
-                        value: {action, messageID}
+                    value: {messages, messageID}
 
         if url
             XHRUtils.fetchMessagesByFolder url, callback

--- a/client/app/stores/message_store.coffee
+++ b/client/app/stores/message_store.coffee
@@ -201,13 +201,9 @@ class MessageStore extends Store
             # Update currentMessageID
             _setCurrentID messageID
 
-            # All messageslist from mailbox are displayed
-            # when a messageDetail must be displayed as well
-            if action is MessageActions.SHOW
-                action = MessageActions.SHOW_ALL
-
-            if action is MessageActions.SHOW_ALL
-                _refreshMailbox payload
+            # Get messageList for 1rst panel
+            if action in [MessageActions.SHOW_ALL, MessageActions.SHOW]
+                _refreshMailbox {mailboxID}
                 _fetchMessages {action, mailboxID, messageID}
 
             @emit 'change'

--- a/client/app/stores/notification_store.coffee
+++ b/client/app/stores/notification_store.coffee
@@ -197,8 +197,8 @@ class NotificationStore extends Store
         handle ActionTypes.ADD_ACCOUNT_FAILURE, ({error}) ->
             AppDispatcher.waitFor [AccountStore.dispatchToken]
             _showNotification
-               message: AccountStore.getAlertErrorMessage()
-               errors: AccountStore.getRawErrors()
+               message: RouterStore.getAlertErrorMessage()
+               errors: RouterStore.getRawErrors()
                autoclose: true
 
         handle ActionTypes.ADD_ACCOUNT_SUCCESS, ({areMailboxesConfigured}) ->
@@ -214,8 +214,8 @@ class NotificationStore extends Store
         handle ActionTypes.EDIT_ACCOUNT_FAILURE, ({error}) ->
             AppDispatcher.waitFor [AccountStore.dispatchToken]
             _showNotification
-               message: AccountStore.getAlertErrorMessage()
-               errors: AccountStore.getRawErrors()
+               message: RouterStore.getAlertErrorMessage()
+               errors: RouterStore.getRawErrors()
                autoclose: true
 
         handle ActionTypes.EDIT_ACCOUNT_SUCCESS, ->
@@ -226,8 +226,8 @@ class NotificationStore extends Store
         handle ActionTypes.CHECK_ACCOUNT_FAILURE, ({error}) ->
             AppDispatcher.waitFor [AccountStore.dispatchToken]
             _showNotification
-               message: AccountStore.getAlertErrorMessage()
-               errors: AccountStore.getRawErrors()
+               message: RouterStore.getAlertErrorMessage()
+               errors: RouterStore.getRawErrors()
                autoclose: true
 
         handle ActionTypes.CHECK_ACCOUNT_SUCCESS, ->

--- a/client/app/stores/router_store.coffee
+++ b/client/app/stores/router_store.coffee
@@ -156,6 +156,7 @@ class RouterStore extends Store
                 (result = {}).flags = flags
         return result
 
+
     _getURIQueryParams = (params={}) ->
         _filter = _.clone _defaultFilter
 
@@ -406,6 +407,7 @@ class RouterStore extends Store
             _modal = params
             @emit 'change'
 
+
         handle ActionTypes.HIDE_MODAL, (value) ->
             _modal = null
             @emit 'change'
@@ -413,6 +415,13 @@ class RouterStore extends Store
         handle ActionTypes.MESSAGE_TRASH_SUCCESS, ({target, updated, ref}) ->
             if (nextMessage = @getNextConversation())?.size
                 _setCurrentMessage nextMessage?.get 'id'
+            @emit 'change'
+
+
+        handle ActionTypes.REFRESH_SUCCESS, ({mailboxID, accountID}) ->
+            # Update URL after refresh,
+            # Views are updated but not URL
+            _router.navigate @getCurrentURL()
             @emit 'change'
 
 

--- a/client/app/stores/router_store.coffee
+++ b/client/app/stores/router_store.coffee
@@ -39,6 +39,9 @@ class RouterStore extends Store
     _accountID = null
     _mailboxID = null
     _tab = null
+    _newAccountWaiting = false
+    _newAccountChecking = false
+    _serverAccountErrorByField = Immutable.Map()
 
     _messageID = null
     _messagesLength = 0
@@ -63,7 +66,31 @@ class RouterStore extends Store
 
 
     getModalParams: ->
-        return _modal
+        _modal
+
+
+    getErrors: ->
+        _serverAccountErrorByField
+
+
+    getRawErrors: ->
+        _serverAccountErrorByField.get 'unknown'
+
+
+    getAlertErrorMessage: ->
+        error = _serverAccountErrorByField.first()
+        if error.name is 'AccountConfigError'
+            return t "config error #{error.field}"
+        else
+            return error.message or error.name or error
+
+
+    isWaiting: ->
+        _newAccountWaiting
+
+
+    isChecking: ->
+        _newAccountChecking
 
 
     getURL: (params={}) ->
@@ -345,6 +372,35 @@ class RouterStore extends Store
         MessageStore.getConversationLength conversationID
 
 
+    _clearError = ->
+        _serverAccountErrorByField = Immutable.Map()
+
+
+    _addError = (field, err) ->
+        _serverAccountErrorByField = _serverAccountErrorByField.set field, err
+
+
+    _checkForNoMailbox = (rawAccount) ->
+        unless rawAccount.mailboxes?.length > 0
+            _setError
+                name: 'AccountConfigError',
+                field: 'nomailboxes'
+                causeFields: ['nomailboxes']
+
+
+    _setError = (error) ->
+        if error.name is 'AccountConfigError'
+            clientError =
+                message: t "config error #{error.field}"
+                originalError: error.originalError
+                originalErrorStack: error.originalErrorStack
+            errorsMap = {}
+            errorsMap[field] = clientError for field in error.causeFields
+            _serverAccountErrorByField = Immutable.Map errorsMap
+
+        else
+            _serverAccountErrorByField = Immutable.Map "unknown": error
+
 
     ###
         Defines here the action handlers.
@@ -391,10 +447,58 @@ class RouterStore extends Store
             _setCurrentAccount()
             @emit 'change'
 
+
+        handle ActionTypes.ADD_ACCOUNT_REQUEST, ({value}) ->
+            _newAccountWaiting = true
+            @emit 'change'
+
+
         handle ActionTypes.ADD_ACCOUNT_SUCCESS, ({account, areMailboxesConfigured}) ->
+            _newAccountWaiting = false
+            _checkForNoMailbox account
             _action = if areMailboxesConfigured
             then MessageActions.SHOW_ALL
             else AccountActions.EDIT
+            @emit 'change'
+
+
+        handle ActionTypes.ADD_ACCOUNT_FAILURE, ({error}) ->
+            _newAccountWaiting = false
+            _setError error
+            @emit 'change'
+
+
+        handle ActionTypes.CHECK_ACCOUNT_REQUEST, () ->
+            _newAccountChecking = true
+            @emit 'change'
+
+
+        handle ActionTypes.CHECK_ACCOUNT_SUCCESS, () ->
+            _newAccountChecking = false
+            @emit 'change'
+
+
+        handle ActionTypes.CHECK_ACCOUNT_FAILURE, ({error}) ->
+            _newAccountChecking = false
+            _setError error
+            @emit 'change'
+
+
+        handle ActionTypes.EDIT_ACCOUNT_REQUEST, ({value}) ->
+            _newAccountWaiting = true
+            @emit 'change'
+
+
+        handle ActionTypes.EDIT_ACCOUNT_SUCCESS, ({rawAccount}) ->
+            _newAccountWaiting = false
+            _checkForNoMailbox rawAccount
+            _clearError()
+            @emit 'change'
+
+
+        handle ActionTypes.EDIT_ACCOUNT_FAILURE, ({error}) ->
+            _newAccountWaiting = false
+            _setError error
             @emit 'change'
 
 
@@ -420,6 +524,7 @@ class RouterStore extends Store
         handle ActionTypes.HIDE_MODAL, (value) ->
             _modal = null
             @emit 'change'
+
 
         handle ActionTypes.MESSAGE_TRASH_SUCCESS, ({target, updated, ref}) ->
             if (nextMessage = @getNextConversation())?.size

--- a/client/app/stores/router_store.coffee
+++ b/client/app/stores/router_store.coffee
@@ -350,17 +350,21 @@ class RouterStore extends Store
 
 
     getNextConversation: ->
-        messageID = @getMessageID()
         messages = @getMessagesList()
-        index = messages?.keyOf MessageStore.getByID messageID
-        messages?.get --index
+        keys = _.keys messages?.toObject()
+        values = messages?.toArray()
+
+        index = keys.indexOf @getMessageID()
+        values[--index]
 
 
     getPreviousConversation: ->
-        messageID = @getMessageID()
         messages = @getMessagesList()
-        index = messages?.keyOf MessageStore.getByID messageID
-        messages?.get ++index
+        keys = _.keys messages?.toObject()
+        values = messages?.toArray()
+
+        index = keys.indexOf @getMessageID()
+        values[++index]
 
 
     getConversationLength: ({messageID, conversationID}) ->

--- a/client/app/stores/router_store.coffee
+++ b/client/app/stores/router_store.coffee
@@ -299,6 +299,9 @@ class RouterStore extends Store
 
 
     isMissingMessages: ->
+        if (messageID = @getMessageID())
+            unless (message = MessageStore.getByID(messageID))?.size
+                return true
         (_messagesLength + 1) < MSGBYPAGE and @hasNextPage()
 
 

--- a/client/app/stores/router_store.coffee
+++ b/client/app/stores/router_store.coffee
@@ -443,6 +443,11 @@ class RouterStore extends Store
             if _isSearchAction()
                 _resetSearch()
 
+            # Update URL if it didnt
+            currentURL = @getCurrentURL isServer: false
+            if location.hash isnt currentURL
+                _router.navigate currentURL
+
             @emit 'change'
 
         handle ActionTypes.ROUTES_INITIALIZE, (router) ->

--- a/client/app/stores/router_store.coffee
+++ b/client/app/stores/router_store.coffee
@@ -156,7 +156,6 @@ class RouterStore extends Store
                 (result = {}).flags = flags
         return result
 
-
     _getURIQueryParams = (params={}) ->
         _filter = _.clone _defaultFilter
 
@@ -407,7 +406,6 @@ class RouterStore extends Store
             _modal = params
             @emit 'change'
 
-
         handle ActionTypes.HIDE_MODAL, (value) ->
             _modal = null
             @emit 'change'
@@ -415,13 +413,6 @@ class RouterStore extends Store
         handle ActionTypes.MESSAGE_TRASH_SUCCESS, ({target, updated, ref}) ->
             if (nextMessage = @getNextConversation())?.size
                 _setCurrentMessage nextMessage?.get 'id'
-            @emit 'change'
-
-
-        handle ActionTypes.REFRESH_SUCCESS, ({mailboxID, accountID}) ->
-            # Update URL after refresh,
-            # Views are updated but not URL
-            _router.navigate @getCurrentURL()
             @emit 'change'
 
 

--- a/client/app/stores/search_store.coffee
+++ b/client/app/stores/search_store.coffee
@@ -62,14 +62,6 @@ class SearchStore extends Store
     ###
     __bindHandlers: (handle) ->
 
-        handle ActionTypes.ROUTE_CHANGE, (params = {}) ->
-            {query} = params
-
-            if query
-                _resetSearch()
-                @emit 'change'
-
-
         handle ActionTypes.SEARCH_PARAMETER_CHANGED, ({search, accountID}) ->
             if search isnt _currentSearch or accountID isnt _currentSearchAccountID
                 _resetSearch()

--- a/client/app/stores/selection_store.coffee
+++ b/client/app/stores/selection_store.coffee
@@ -35,10 +35,6 @@ class SelectionStore extends Store
     ###
     __bindHandlers: (handle) ->
 
-        handle ActionTypes.ROUTE_CHANGE, ->
-            _resetSelection()
-            @emit 'change'
-
         handle ActionTypes.MAILBOX_SELECT_ALL, ->
             if _isAllSelected
                 _resetSelection()

--- a/client/app/utils/api_utils.coffee
+++ b/client/app/utils/api_utils.coffee
@@ -101,42 +101,39 @@ module.exports = Utils =
     # `top` key     -> direction is prev
     # `bottom` key  -> direction is next
     messageNavigate: (direction) ->
-        if 'prev' is direction
-            messageID = RouterStore.getNextConversation()?.get 'id'
-        else
-            messageID = RouterStore.getPreviousConversation()?.get 'id'
-        RouterActionCreator.navigate {messageID}
+        message = if 'prev' is direction
+        then RouterStore.getNextConversation()
+        else RouterStore.getPreviousConversation()
+
+        messageID = message?.get 'id'
+        mailboxID = message?.get 'mailboxID'
+        RouterActionCreator.gotoMessage {messageID, mailboxID}
 
 
     ##
     # Display a message
     # @params {Immutable} message the message (current one if null)
     messageDisplay: (message) ->
-        messageID = message?.get('id') or RouterStore.getMessageID()
-        RouterActionCreator.navigate {messageID}
+        messageID = message?.get 'id'
+        mailboxID = message?.get 'mailboxID'
+        RouterActionCreator.gotoMessage {messageID, mailboxID}
 
 
     messageClose: ->
-        url = window.location.href
-        url = url.replace /\/message\/[\w-]+/gi, ''
-        url = url.replace /\/conversation\/[\w-]+\/[\w-]+/gi, ''
-        url = url.replace /\/edit\/[\w-]+/gi, ''
-        RouterActionCreator.navigate {url}
+        RouterActionCreator.closeMessage()
+
 
     messageDeleteCurrent: ->
         messageID = RouterStore.getMessageID()
         if not onMessageList() or not messageID?
             return
 
-        deleteMessage = (isModal) ->
+        deleteMessage = ->
             MessageActionCreator.delete {messageID}
-            RouterActionCreator.navigate action: MessageActions.GROUP_NEXT
-
-        settings = SettingsStore.get()
 
         # Delete Message without modal
-        unless (confirm = settings.get 'messageConfirmDelete')
-            deleteMessage false
+        unless SettingsStore.get 'messageConfirmDelete'
+            deleteMessage()
             return
 
         # Display 'delete' modal

--- a/client/app/utils/api_utils.coffee
+++ b/client/app/utils/api_utils.coffee
@@ -13,8 +13,8 @@ RouterGetter = require '../getters/router'
 AccountStore  = require '../stores/account_store'
 MessageStore  = require '../stores/message_store'
 RouterStore  = require '../stores/router_store'
-
 SettingsStore = require '../stores/settings_store'
+
 LayoutActionCreator  = require '../actions/layout_action_creator'
 MessageActionCreator = require '../actions/message_action_creator'
 RouterActionCreator  = require '../actions/router_action_creator'
@@ -33,22 +33,20 @@ module.exports = Utils =
 
 
     getCurrentAccount: ->
-        AccountStore.getSelected()?.toJS()
+        RouterStore.getAccount()?.toJS()
 
 
     getCurrentMailbox: ->
-        AccountStore.getMailbox()?.toJS()
+        RouterStore.getMailbox()?.toJS()
 
 
     getCurrentMessage: ->
-        messageID = MessageStore.getCurrentID()
-        message = MessageStore.getByID messageID
-        return message?.toJS()
+        messageID = RouterStore.getMessageID()
+        Utils.getMessage messageID
 
 
-    getMessage: (id) ->
-        message = MessageStore.getByID id
-        return message?.toJS()
+    getMessage: (messageID) ->
+        MessageStore.getByID(messageID)?.toJS()
 
     getCurrentActions: ->
         res = []
@@ -104,9 +102,9 @@ module.exports = Utils =
     # `bottom` key  -> direction is next
     messageNavigate: (direction) ->
         if 'prev' is direction
-            messageID = MessageStore.getNextConversation()?.get 'id'
+            messageID = RouterStore.getNextConversation()?.get 'id'
         else
-            messageID = MessageStore.getPreviousConversation()?.get 'id'
+            messageID = RouterStore.getPreviousConversation()?.get 'id'
         RouterActionCreator.navigate {messageID}
 
 
@@ -123,7 +121,7 @@ module.exports = Utils =
     # Display a message
     # @params {Immutable} message the message (current one if null)
     messageDisplay: (message) ->
-        messageID = message?.get('id') or MessageStore.getCurrentID()
+        messageID = message?.get('id') or RouterStore.getMessageID()
         RouterActionCreator.navigate {messageID}
 
 
@@ -135,7 +133,7 @@ module.exports = Utils =
         RouterActionCreator.navigate {url}
 
     messageDeleteCurrent: ->
-        messageID = MessageStore.getCurrentID()
+        messageID = RouterStore.getMessageID()
         if not onMessageList() or not messageID?
             return
 
@@ -169,8 +167,8 @@ module.exports = Utils =
     simulateUpdate: ->
         window.setInterval ->
             content =
-                "accountID": AccountStore.getAccountID()
-                "id": AccountStore.getMailboxID()
+                "accountID": RouterStore.getAccountID()
+                "id": RouterStore.getMailboxID()
                 "label": "INBOX",
                 "path": "INBOX",
                 "tree": ["INBOX"],

--- a/client/app/utils/api_utils.coffee
+++ b/client/app/utils/api_utils.coffee
@@ -108,15 +108,6 @@ module.exports = Utils =
         RouterActionCreator.navigate {messageID}
 
 
-    messageSetCurrent: (message) ->
-        return unless message?.get('id')
-
-        MessageActionCreator.setCurrent message.get('id'), true
-
-        if SettingsStore.get('displayPreview')
-            @messageDisplay message
-
-
     ##
     # Display a message
     # @params {Immutable} message the message (current one if null)

--- a/client/app/utils/api_utils.coffee
+++ b/client/app/utils/api_utils.coffee
@@ -57,7 +57,7 @@ module.exports = Utils =
 
 
     messageNew: ->
-        router.navigate('compose/', {trigger: true})
+        RouterActionCreator.gotoCompose()
 
 
     # update locate (without saving it into settings)

--- a/client/app/utils/xhr_utils.coffee
+++ b/client/app/utils/xhr_utils.coffee
@@ -1,15 +1,6 @@
 request = require 'superagent'
 _       = require 'underscore'
 
-AccountTranslator = require './translators/account_translator'
-
-SettingsStore = require '../stores/settings_store'
-RouterStore = require '../stores/router_store'
-AccountStore = require '../stores/account_store'
-MessageStore = require '../stores/message_store'
-
-{MessageActions} = require '../constants/app_constants'
-
 discovery2Fields = require '../utils/discovery_to_fields'
 
 

--- a/client/app/utils/xhr_utils.coffee
+++ b/client/app/utils/xhr_utils.coffee
@@ -36,11 +36,15 @@ module.exports =
         .send settings
         .end handleResponse callback, 'changeSettings', settings
 
-    fetchConversation: (conversationID, callback) ->
-        request.get "messages/batchFetch?conversationID=#{conversationID}"
+    fetchConversation: ({messageID, conversationID}, callback) ->
+        query = if conversationID
+        then "conversationID=#{conversationID}"
+        else "messageID=#{messageID}"
+
+        request.get "messages/batchFetch?#{query}"
         .set 'Accept', 'application/json'
         .end (err, res) ->
-            _cb = handleResponse callback, 'fetchConversation', conversationID
+            _cb = handleResponse callback, 'fetchConversation', {messageID, conversationID}
             _cb err, res
 
     fetchMessagesByFolder: (url, callback) ->

--- a/doc/routes.md
+++ b/doc/routes.md
@@ -70,29 +70,19 @@ Complex filters (in opposite to boolean filters like previous) can have paramete
 
 ## Redirection
 
-2 cases exist :
- - a redirection from the view,
- - or a redirection from an `action`.
+Redirection is handled after updating `RouterStore`. Here is the list of properties that should update URL :
+ - `action`: get from `routes` the right URL pattern,
+ - `mailboxID`: the ID of the mailbox,
+ - `MessageID`: the ID of selected message,
+ - `query` : filters into messages list,
+ - `tab` : change `tabComponent` (ie. `accountEdit`)
 
-### Use a basic link into view
-You need to go to a specific page with a `click` action ?
- - `RouterGetter.getURL(params)` will return the right URL for `params`
- - define `params` as smaller as you can : `Stores` knows everything for you!
+ Whats happening into `routerStore`:
 
-### Make a redirection from stores
-A message is deleted, then you need to select the next message from the list?
-First of all: do not redirect into the view but listen to `ActionType.RECEIVE_MESSAGE_DELETE` into `RouterStore`, such as:
+ Each property related to route is changed after `ActionTypes.ROUTE_CHANGE` into `routerStore` file. After all updates are done, the URL is updated if needed :
 
  ```
- handle ActionTypes.MESSAGE_TRASH_SUCCESS, (params) ->
-     if MessageActions.SHOW is _action
-         if (messageID = params?.next?.get 'id')
-             _router.navigate @getURL {messageID}
-         else
-             _action = MessageActions.SHOW_ALL
-         @emit 'change'
+ currentURL = @getCurrentURL isServer: false
+ if location.hash isnt currentURL
+     _router.navigate currentURL
 ```
-
-If context (that should be updated) isnt from `RouterStore` (ie. `messageID` is `MessageStore`):
- - then use `_router.navigate` with the right params,
- - Otherwhise, update `local` variable, and emit a `change` event.

--- a/tests/client-units/account_store.coffee
+++ b/tests/client-units/account_store.coffee
@@ -21,7 +21,7 @@ describe 'AccountStore initialized without account', ->
         should.not.exist AccountStore.getDefault()
 
     it 'Then AccountStore.isWaiting is true', ->
-        AccountStore.isWaiting().should.be.true
+        RouterStore.isWaiting().should.be.true
 
     it 'When i receive a successful response (with no mailboxes)', ->
         dispatch ActionTypes.ADD_ACCOUNT_SUCCESS, account:
@@ -41,10 +41,10 @@ describe 'AccountStore initialized without account', ->
         AccountStore.getAccountID().should.equal 'testid'
 
     it 'Then AccountStore.isWaiting is false', ->
-        AccountStore.isWaiting().should.be.false
+        RouterStore.isWaiting().should.be.false
 
     it 'Then AccountStore should have a nomailboxes error', ->
-        noMailboxErr = AccountStore.getErrors().get('nomailboxes')
+        noMailboxErr = RouterStore.getErrors().get('nomailboxes')
         noMailboxErr.message.should.equal 'translated config error nomailboxes'
 
     it 'When i send a request to create a second account', ->
@@ -54,7 +54,7 @@ describe 'AccountStore initialized without account', ->
         AccountStore.getDefault().get('id').should.equal 'testid'
 
     it 'Then AccountStore.isWaiting is true', ->
-        AccountStore.isWaiting().should.be.true
+        RouterStore.isWaiting().should.be.true
 
     it 'When i receive an error response', ->
         dispatch ActionTypes.ADD_ACCOUNT_FAILURE, error:
@@ -66,14 +66,14 @@ describe 'AccountStore initialized without account', ->
         AccountStore.getDefault().get('id').should.equal 'testid'
 
     it 'Then AccountStore.isWaiting is false', ->
-        AccountStore.isWaiting().should.be.false
+        RouterStore.isWaiting().should.be.false
 
     it 'Then AccountStore should have some errors', ->
-        should.exist AccountStore.getErrors().get('smtp')
-        error = AccountStore.getErrors().get('smtp')
+        should.exist RouterStore.getErrors().get('smtp')
+        error = RouterStore.getErrors().get('smtp')
         error.message.should.equal 'translated config error smtp'
-        error.should.equal AccountStore.getErrors().get('smtpLogin')
-        error.should.equal AccountStore.getErrors().get('smtpPort')
+        error.should.equal RouterStore.getErrors().get('smtpLogin')
+        error.should.equal RouterStore.getErrors().get('smtpPort')
 
 TEST_ACCOUNT =
     id: 'testid'

--- a/tests/client-units/helpers.coffee
+++ b/tests/client-units/helpers.coffee
@@ -17,7 +17,7 @@ requireNoCache = (modulePath) ->
     return require modulePathResolved
 
 exports.getCleanStore = (which) ->
-    Dispatcher = requireNoCache '../../client/app/app_dispatcher'
+    Dispatcher = requireNoCache '../../client/app/libs/flux/dispatcher/dispatcher'
     Store = requireNoCache "../../client/app/stores/#{which}"
     dispatch = (type, value) -> Dispatcher.dispatch {type, value}
     return {dispatch, Store}


### PR DESCRIPTION
Too much regressions since PR #823, #814 (applications states are not reflecting routes); move all states related to `route` into `routerStore`.

## Fix features
 - [x] right panel should be closed when a message is closed,
 - [x] when `mailbox` changes (click on `mailbox` link) messages should be updated,
 - [x] button `load more` should load next messages if they exists, otherwise do not display the button.
 - [x] FIX infinite load on `trashMailbox`,
 - [x] goto `nextConversation`when a message is deleted,
 - [ ] remove message from list when a message is deleted,
 - [x] fetch all messages when showing a conversation,
 - [x] fetch messages until selected message is found,
 - [x] fetch all conversation when displaying a message,
 - [x] a message detail is closed when use click on mailboxLink,

## Add feature
 - [x] add counter to `flaggedMailbox`,
 - [x] add paginate information (not visible but exists into `RouterActionCreator`).

## Clean
 - [x] replace `RouterActionCreator.navigate` by other actions
