### PR TITLE
Clean Mailbox Menu

### DIFF
--- a/client/app/components/application.coffee
+++ b/client/app/components/application.coffee
@@ -97,6 +97,10 @@ module.exports = React.createClass
                     composeURL      : composeURL
                     newAccountURL   : newAccountURL
                     mailboxes       : RouterGetter.getMailboxes()
+                    nbTotal         : RouterGetter.getTotalLength()
+                    nbUnread        : RouterGetter.getUnreadLength()
+                    nbRecent        : RouterGetter.getRecentLength()
+
 
                 main
                     className: @props.layout

--- a/client/app/components/menu.coffee
+++ b/client/app/components/menu.coffee
@@ -135,13 +135,6 @@ module.exports = Menu = React.createClass
                                     className: 'item-label display-login'
                                     account.get 'login'
 
-                a
-                    href: props.configURL
-                    className: 'mailbox-config menu-subaction',
-                    i
-                        'className': 'fa fa-cog'
-                        'aria-describedby': Tooltips.ACCOUNT_PARAMETERS
-                        'data-tooltip-direction': 'right'
 
             if props.isSelected
                 ul

--- a/client/app/components/menu.coffee
+++ b/client/app/components/menu.coffee
@@ -66,12 +66,6 @@ module.exports = Menu = React.createClass
                         span className: 'item-label',
                         t 'menu account new'
 
-                button
-                    role: 'menuitem'
-                    className: 'btn fa fa-question-circle help'
-                    'aria-describedby': Tooltips.HELP_SHORTCUTS
-                    'data-tooltip-direction': 'top'
-                    onClick: -> Mousetrap.trigger '?'
 
     renderMailboxesFlags: (params={}) ->
         {flags, type, progress, slug, total, unread} = params

--- a/client/app/components/menu_mailbox_item.coffee
+++ b/client/app/components/menu_mailbox_item.coffee
@@ -14,8 +14,10 @@ AccountActionCreator = require '../actions/account_action_creator'
 module.exports = React.createClass
     displayName: 'MenuMailboxItem'
 
+
     getInitialState: ->
         return target: false
+
 
     getDefaultProps: ->
         return {
@@ -25,6 +27,7 @@ module.exports = React.createClass
             }
         }
 
+
     getTitle: ->
         title = t "menu mailbox total", @props.total
         if @props.unread
@@ -32,6 +35,7 @@ module.exports = React.createClass
         if @props.recent
             title += t "menu mailbox new", @props.recent
         return title
+
 
     render: ->
         classesParent = classNames

--- a/client/app/components/menu_mailbox_item.coffee
+++ b/client/app/components/menu_mailbox_item.coffee
@@ -51,11 +51,6 @@ module.exports = React.createClass
                 className: "#{classesChild} lv-#{@props.depth}"
                 role: 'menuitem'
                 'data-mailbox-id': @props.mailboxID
-                onDragEnter: @onDragEnter
-                onDragLeave: @onDragLeave
-                onDragOver: @onDragOver
-                onDrop: (e) =>
-                    @onDrop e, @props.mailboxID
                 title: @getTitle()
                 'data-toggle': 'tooltip'
                 'data-placement' : 'right'
@@ -81,23 +76,6 @@ module.exports = React.createClass
             if not @props.progress and @props.unread
                 span className: 'badge', @props.unread
 
-
-    onDragEnter: (e) ->
-        if not @state.target
-            @setState target: true
-
-    onDragLeave: (e) ->
-        if @state.target
-            @setState target: false
-
-    onDragOver: (e) ->
-        e.preventDefault()
-
-    onDrop: (event, to) ->
-        data = event.dataTransfer.getData('text')
-        {messageID, mailboxID, conversationID} = JSON.parse data
-        @setState target: false
-        RouterActionCreator.move {messageID, conversationID}, mailboxID, to
 
     expungeMailbox: (event) ->
         event.preventDefault()

--- a/client/app/components/menu_mailbox_item.coffee
+++ b/client/app/components/menu_mailbox_item.coffee
@@ -64,28 +64,6 @@ module.exports = React.createClass
                     span className: 'refresh-error', onClick: displayError,
                         i className: 'fa fa-warning', null
 
-            if 'trashMailbox' is @props.icon?.type
-                button
-                    className:                'menu-subaction'
-                    'aria-describedby':       Tooltips.EXPUNGE_MAILBOX
-                    'data-tooltip-direction': 'right'
-                    onClick: @expungeMailbox
-
-                    span className: 'fa fa-recycle'
 
             if not @props.progress and @props.unread
                 span className: 'badge', @props.unread
-
-
-    expungeMailbox: (event) ->
-        event.preventDefault()
-        LayoutActionCreator.displayModal
-            title       : t 'app confirm delete'
-            subtitle    : t 'account confirm delbox'
-            closeLabel  : t 'app cancel'
-            actionLabel : t 'app confirm'
-            action      : =>
-                LayoutActionCreator.hideModal()
-                AccountActionCreator.mailboxExpunge
-                    accountID: @props.accountID
-                    mailboxID: @props.mailboxID

--- a/client/app/components/message-list-item.coffee
+++ b/client/app/components/message-list-item.coffee
@@ -1,4 +1,3 @@
-_          = require 'underscore'
 React      = require 'react'
 classNames = require 'classnames'
 
@@ -15,6 +14,7 @@ Participants = React.createFactory require './participants'
 MessageGetter = require '../getters/message'
 ContactGetter = require '../getters/contact'
 SearchGetter = require '../getters/search'
+
 
 module.exports = React.createClass
     displayName: 'MessagesItem'
@@ -88,13 +88,6 @@ module.exports = React.createClass
         text = (text or '').substr 0, 1024
         props = SearchGetter.highlightSearch text
         p options, props...
-
-
-    onSelect: (event) ->
-        event.stopPropagation()
-        id = @props.message.get 'id'
-        value = not @props.isSelected
-        LayoutActionCreator.updateSelection {id, value}
 
 
     onMessageClick: (event) ->

--- a/client/app/getters/router.coffee
+++ b/client/app/getters/router.coffee
@@ -118,6 +118,18 @@ module.exports =
         RouterStore.getInbox accountID
 
 
+    getTotalLength: ->
+        @getInbox()?.get 'nbTotal'
+
+
+    getUnreadLength: ->
+        @getInbox()?.get 'nbUnread'
+
+
+    getRecentLength: ->
+        @getInbox()?.get 'nbRecent'
+
+
     getTrashMailbox: (accountID) ->
         accountID ?= @getAccountID()
         RouterStore.getTrashMailbox accountID

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -35,7 +35,6 @@ class AccountStore extends Store
             return 2
         .map (mailbox) ->
             mailbox.depth = mailbox.tree.length - 1
-            console.log mailbox
             delete mailbox.tree
             Immutable.Map mailbox
         .toOrderedMap()

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -23,8 +23,12 @@ class AccountStore extends Store
             (new RegExp tag).test label.toLowerCase()
 
 
-    # Creates Immutable OrderedMap of mailboxes
     _toImmutable = (account) ->
+
+        # Do not get NoSelect mailbox
+        # cf https://tools.ietf.org/html/rfc3501#page-69
+        mailboxes = _.filter account.mailboxes, (mailbox) ->
+            -1 is mailbox.attribs.indexOf '\\Noselect'
 
         account.mailboxes = Immutable.Iterable mailboxes
         .toKeyedSeq()

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -19,8 +19,8 @@ class AccountStore extends Store
 
 
     _isSpecialMailbox = (mailbox) ->
-        label = mailbox.label.toLowerCase()
-        _.find [/draft/, /sent/, /trash/], (regExp) -> regExp.test label
+        _.find ['draft', 'sent', 'trash'], (tag) ->
+            (new RegExp tag).test label.toLowerCase()
 
 
     # Creates Immutable OrderedMap of mailboxes

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -14,11 +14,11 @@ class AccountStore extends Store
     _accounts = Immutable.Iterable()
 
 
-    _isInbox = ({label}) ->
+    _isInbox = (label) ->
         'inbox' is label.toLowerCase()
 
 
-    _isSpecialMailbox = (mailbox) ->
+    _isSpecialMailbox = (label) ->
         _.find ['draft', 'sent', 'trash'], (tag) ->
             (new RegExp tag).test label.toLowerCase()
 
@@ -34,8 +34,8 @@ class AccountStore extends Store
         .toKeyedSeq()
         .mapKeys (_, mailbox) -> mailbox.id
         .sort (mailbox) ->
-            return 0 if _isInbox {label: mailbox.tree[0]}
-            return 1 if _isSpecialMailbox mailbox
+            return 0 if _isInbox mailbox.tree[0]
+            return 1 if _isSpecialMailbox mailbox.tree[0]
             return 2
         .map (mailbox) ->
             mailbox.depth = mailbox.tree.length - 1

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -1,4 +1,5 @@
 Immutable = require 'immutable'
+_ = require 'lodash'
 
 Store = require '../libs/flux/store/store'
 
@@ -12,49 +13,33 @@ class AccountStore extends Store
     ###
     _accounts = Immutable.Iterable()
 
-    _sortMailbox = (mailbox) ->
-        last = {}
-        weight1 = 900
-        weight2 = 400
 
-        mailbox.depth = mailbox.tree.length - 1
-
-        # fake weight for sort
-        if mailbox.depth is 0
-            if 'inbox' is (label = mailbox.label.toLowerCase())
-                mailbox.weight = 1000
-
-            else if (mailbox.attribs.length > 0 or
-                    /draft/.test(label) or
-                    /sent/.test(label) or
-                    /trash/.test(label))
-                mailbox.weight = weight1
-                weight1 -= 5
-
-            else
-                mailbox.weight = weight2
-                weight2 -= 5
-
-            last[mailbox.depth] = mailbox.weight
-        else
-            mailbox.weight = last[mailbox.depth - 1] - 0.1
-            last[mailbox.depth] = mailbox.weight
-
-        mailbox
+    _isInbox = ({label}) ->
+        'inbox' is label.toLowerCase()
 
 
+    _isSpecialMailbox = (mailbox) ->
+        label = mailbox.label.toLowerCase()
+        _.find [/draft/, /sent/, /trash/], (regExp) -> regExp.test label
+
+
+    # Creates Immutable OrderedMap of mailboxes
     _toImmutable = (account) ->
-        # Creates Immutable OrderedMap of mailboxes
-        mailboxes = Immutable.Iterable account.mailboxes
+        account.mailboxes = Immutable.Iterable account.mailboxes
         .toKeyedSeq()
         .mapKeys (_, mailbox) -> mailbox.id
-
-        # Sort mailboxes by depth
-        .map (mailbox) -> Immutable.Map _sortMailbox mailbox
+        .sort (mailbox) ->
+            return 0 if _isInbox {label: mailbox.tree[0]}
+            return 1 if _isSpecialMailbox mailbox
+            return 2
+        .map (mailbox) ->
+            mailbox.depth = mailbox.tree.length - 1
+            console.log mailbox
+            delete mailbox.tree
+            Immutable.Map mailbox
         .toOrderedMap()
 
         delete account.totalUnread
-        account.mailboxes = mailboxes
         return Immutable.Map account
 
 
@@ -98,17 +83,6 @@ class AccountStore extends Store
                 account = account.set 'mailboxes', mailboxes
 
                 _accounts = _accounts.set accountID, account
-
-
-    _mailboxSort = (mb1, mb2) ->
-        w1 = mb1.get 'weight'
-        w2 = mb2.get 'weight'
-        if w1 < w2 then return 1
-        else if w1 > w2 then return -1
-        else
-            if mb1.get 'label' < mb2.get 'label' then return 1
-            else if mb1.get 'label' > mb2.get 'label' then return -1
-            else return 0
 
 
     _updateAccount = (rawAccount) ->
@@ -194,7 +168,6 @@ class AccountStore extends Store
         if accountID
             _accounts?.get accountID
                 .get 'mailboxes'
-                .sort _mailboxSort
 
 
     makeEmptyAccount: ->

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -26,10 +26,6 @@ class AccountStore extends Store
     # Creates Immutable OrderedMap of mailboxes
     _toImmutable = (account) ->
 
-        # Remove duplicated mailbox
-        labels = _.groupBy account.mailboxes, 'label'
-        mailboxes = _.map labels, (values, key) -> values[0]
-
         account.mailboxes = Immutable.Iterable mailboxes
         .toKeyedSeq()
         .mapKeys (_, mailbox) -> mailbox.id

--- a/client/app/stores/account_store.coffee
+++ b/client/app/stores/account_store.coffee
@@ -25,7 +25,12 @@ class AccountStore extends Store
 
     # Creates Immutable OrderedMap of mailboxes
     _toImmutable = (account) ->
-        account.mailboxes = Immutable.Iterable account.mailboxes
+
+        # Remove duplicated mailbox
+        labels = _.groupBy account.mailboxes, 'label'
+        mailboxes = _.map labels, (values, key) -> values[0]
+
+        account.mailboxes = Immutable.Iterable mailboxes
         .toKeyedSeq()
         .mapKeys (_, mailbox) -> mailbox.id
         .sort (mailbox) ->


### PR DESCRIPTION
 - [x] fix `depth` issues,
 - [x] do not display mailbox with tags `\Noselect`,
 - [x] remove `settingsButton`,
 - [x] remove `dragEvents` on `mailboxLinks`.
 - [x] remove `expungeMailbox` (have to be fixed),
 - [x] remove `editAccountLink` (this page has to be fixed).