### PR TITLE
Fix Mailbox order into Menu

### DIFF
--- a/client/app/components/application.coffee
+++ b/client/app/components/application.coffee
@@ -98,9 +98,8 @@ module.exports = React.createClass
                     composeURL      : composeURL
                     newAccountURL   : newAccountURL
                     mailboxes       : RouterGetter.getMailboxes()
-                    nbTotal         : RouterGetter.getTotalLength()
                     nbUnread        : RouterGetter.getUnreadLength()
-                    nbRecent        : RouterGetter.getRecentLength()
+                    nbFlagged       : RouterGetter.getFlaggedLength()
 
 
                 main

--- a/client/app/components/menu.coffee
+++ b/client/app/components/menu.coffee
@@ -70,13 +70,13 @@ module.exports = Menu = React.createClass
     renderMailboxesFlags: (params={}) ->
         {flags, type, progress, slug, total, unread} = params
 
-        mailbox = RouterGetter.getInbox()
+        mailboxID = @props.mailboxes.toArray()[0].get 'id'
         mailboxURL = RouterGetter.getURL
-            mailboxID: (mailboxID = mailbox.get 'id')
+            mailboxID: mailboxID
             filter: {flags}
 
         MenuMailboxItem
-            accountID:      RouterGetter.getAccountID()
+            accountID:      @props.accountID
             mailboxID:      mailboxID
             label:          t "mailbox title #{slug}"
             key:            "mailbox-item-#{slug}"
@@ -92,15 +92,17 @@ module.exports = Menu = React.createClass
     # renders a single account and its submenu
     # TODO : make a component for this
     renderMailBoxes: (account) ->
+        mailboxes = @props.mailboxes.toArray()
+        inbox = mailboxes[0]
+
         # Goto the default mailbox of the account
         action = MessageActions.SHOW_ALL
         accountID = account.get 'id'
-        mailbox = RouterGetter.getInbox(accountID)
-        mailboxID = mailbox?.get 'id'
+        mailboxID = inbox?.get 'id'
         mailboxURL = RouterGetter.getURL {action, mailboxID, resetFilter: true}
 
         props = {
-            isSelected: accountID is RouterGetter.getAccountID()
+            isSelected: accountID is @props.accountID
             mailboxURL: mailboxURL
             configURL: RouterGetter.getURL
                 action: AccountActions.EDIT
@@ -110,7 +112,6 @@ module.exports = Menu = React.createClass
             progress: RouterGetter.getProgress accountID
         }
 
-        mailboxes = @props.mailboxes.toArray()
         className = classNames active: props.isSelected
         div
             className: className
@@ -165,14 +166,14 @@ module.exports = Menu = React.createClass
                         type: 'unreadMailbox'
                         flags: MessageFilter.UNSEEN
                         progress: props.progress
-                        total: (total = RouterGetter.getInbox().get 'nbUnread')
-                        unread: total
+                        total: @props.nbUnread
+                        unread: @props.nbUnread
                         slug: 'unread'
 
                     @renderMailboxesFlags
                         type: 'flaggedMailbox'
                         flags: MessageFilter.FLAGGED
                         progress: props.progress
-                        total: (total = RouterGetter.getInbox().get 'nbFlagged')
-                        unread: total
+                        total: @props.nbFlagged
+                        unread: @props.nbFlagged
                         slug: 'flagged'

--- a/client/app/components/menu.coffee
+++ b/client/app/components/menu.coffee
@@ -151,7 +151,7 @@ module.exports = Menu = React.createClass
                             accountID:      account.get 'id'
                             mailboxID:      mailboxID
                             label:          mailbox.get 'label'
-                            depth:          mailbox.get 'depth'
+                            depth:          mailbox.get('tree').length - 1
                             isActive:       RouterGetter.isCurrentURL mailboxURL
                             displayErrors:  @displayErrors
                             progress:       props.progress

--- a/client/app/components/menu_mailbox_item.coffee
+++ b/client/app/components/menu_mailbox_item.coffee
@@ -44,7 +44,6 @@ module.exports = React.createClass
 
         classesChild = classNames
             target:  @state.target
-            special: @props.icon.type
             news:    @props.recent > 0
 
         displayError = @props.displayErrors.bind null, @props.progress

--- a/client/app/getters/router.coffee
+++ b/client/app/getters/router.coffee
@@ -120,16 +120,12 @@ module.exports =
         RouterStore.getInbox accountID
 
 
-    getTotalLength: ->
-        @getInbox()?.get 'nbTotal'
-
-
     getUnreadLength: ->
         @getInbox()?.get 'nbUnread'
 
 
-    getRecentLength: ->
-        @getInbox()?.get 'nbRecent'
+    getFlaggedLength: ->
+        @getInbox()?.get 'nbFlagged'
 
 
     getTrashMailbox: (accountID) ->


### PR DESCRIPTION
 - [x] `mailboxTree` must be valid,
 - [x] `inbox` should be on top list,
 - [x] move `unreadMailbox` after `inbox`,
 - [x] move `flaggedMailbox` after `inbox`.