### PR TITLE
[fix] flickery advanced params opening at submission

### DIFF
--- a/client/app/components/accounts/wizard/creation.cjsx
+++ b/client/app/components/accounts/wizard/creation.cjsx
@@ -174,9 +174,7 @@ module.exports = AccountWizardCreation = React.createClass
     create: (event) ->
         event.preventDefault()
 
-        @setState alert: null
-
-        if @state.isDiscoverable
+        if @state.isDiscoverable and not(@state.imapServer or @state.smtpServer)
             [..., domain] = @state.login.split '@'
             AccountActionCreator.discover domain, @sanitizeConfig @state
         else


### PR DESCRIPTION
This PR fix an unwanted behavior that open advanced parameters when re-triggering an AUTH_CHECK request on autodiscovered account.