### PR TITLE
Clean from #839 comments

### DIFF
--- a/client/app/actions/account_action_creator.coffee
+++ b/client/app/actions/account_action_creator.coffee
@@ -2,13 +2,13 @@
 
 _ = require 'underscore'
 
-XHRUtils      = require '../libs/xhr'
+AccountsUtils = require '../libs/accounts'
 AppDispatcher = require '../libs/flux/dispatcher/dispatcher'
+XHRUtils      = require '../libs/xhr'
 
 AccountStore = require '../stores/account_store'
 RouterStore  = require '../stores/router_store'
 
-AccountMixin = require '../mixins/account_mixin'
 
 
 module.exports = AccountActionCreator =
@@ -114,8 +114,8 @@ module.exports = AccountActionCreator =
             # same methods the view component uses by exploiting same mixins).
             # Also, dispatch a success event for the discovery action.
             else
-                servers = AccountMixin.parseProviders provider
-                config  = AccountMixin.sanitizeConfig _.extend config, servers
+                servers = AccountsUtils.parseProviders provider
+                config  = AccountsUtils.sanitizeConfig _.extend config, servers
 
                 AccountActionCreator.check value: config
 

--- a/client/app/components/account_config.coffee
+++ b/client/app/components/account_config.coffee
@@ -41,10 +41,10 @@ module.exports = React.createClass
         nstate = {}
 
         # dont overwrite editedAccount when stores state changed
-        nstate.serverErrors      = RouterStore.getErrors()
+        # nstate.serverErrors      = RouterStore.getErrors()
         nstate.selectedAccount   = RouterStore.getAccount()
-        nstate.isWaiting         = RouterStore.isWaiting()
-        nstate.isChecking        = RouterStore.isChecking()
+        # nstate.isWaiting         = RouterStore.isWaiting()
+        # nstate.isChecking        = RouterStore.isChecking()
 
         # unless (nstate.editedAccount = nstate.selectedAccount)
         #     nstate.editedAccount = AccountStore.makeEmptyAccount()

--- a/client/app/components/accounts/wizard/creation.cjsx
+++ b/client/app/components/accounts/wizard/creation.cjsx
@@ -10,7 +10,7 @@ ReactDOM = require 'react-dom'
 Form    = require '../../basics/form'
 Servers = require '../servers'
 
-RequestsInFlightStore = require '../../../stores/requests_in_flight_store'
+RequestsStore = require '../../../stores/requests_store'
 
 RouterGetter = require '../../../getters/router'
 
@@ -32,12 +32,12 @@ module.exports = AccountWizardCreation = React.createClass
     displayName: 'AccountWizardCreation'
 
     mixins: [
-        StoreWatchMixin [RequestsInFlightStore]
+        StoreWatchMixin [RequestsStore]
         AccountMixin
     ]
 
 
-    # Build state form RequestsInFlightStore:
+    # Build state form RequestsStore:
     # - is an autodiscover request in action, or a provider available?
     getStateFromStores: ->
         state       = {}

--- a/client/app/components/accounts/wizard/creation.cjsx
+++ b/client/app/components/accounts/wizard/creation.cjsx
@@ -1,9 +1,10 @@
 {IMAP_OPTIONS} = require '../../../constants/defaults'
 {OAuthDomains} = require '../../../constants/app_constants'
 
-_        = require 'underscore'
-React    = require 'react'
-ReactDOM = require 'react-dom'
+_             = require 'underscore'
+React         = require 'react'
+ReactDOM      = require 'react-dom'
+AccountsUtils = require '../../../libs/accounts'
 
 Form    = require '../../basics/form'
 Servers = require '../servers'
@@ -16,7 +17,6 @@ AccountActionCreator = require '../../../actions/account_action_creator'
 RouterActionCreator = require '../../../actions/router_action_creator'
 
 StoreWatchMixin = require '../../../mixins/store_watch_mixin'
-AccountMixin    = require '../../../mixins/account_mixin'
 
 
 module.exports = AccountWizardCreation = React.createClass
@@ -25,7 +25,6 @@ module.exports = AccountWizardCreation = React.createClass
 
     mixins: [
         StoreWatchMixin [RequestsStore]
-        AccountMixin
     ]
 
 
@@ -41,7 +40,7 @@ module.exports = AccountWizardCreation = React.createClass
             OAuth:          RequestsGetter.isAccountOAuth()
 
         state.success = _.partial @redirect, account if account
-        _.extend state, @parseProviders discover if discover
+        _.extend state, AccountsUtils.parseProviders discover if discover
 
         return state
 
@@ -123,9 +122,11 @@ module.exports = AccountWizardCreation = React.createClass
 
         if @state.isDiscoverable and not(@state.imapServer or @state.smtpServer)
             [..., domain] = @state.login.split '@'
-            AccountActionCreator.discover domain, @sanitizeConfig @state
+            AccountActionCreator.discover domain,
+                AccountsUtils.sanitizeConfig @state
         else
-            AccountActionCreator.check value: @sanitizeConfig @state
+            AccountActionCreator.check
+                value: AccountsUtils.sanitizeConfig @state
 
 
     # Disable autodiscover when advanced settings are expanded
@@ -167,4 +168,5 @@ module.exports = AccountWizardCreation = React.createClass
             @setState source
         else
             {target: {value}} = event
-            @setState _.partial @validateAccountState, source, value
+            nextState = _.partial AccountsUtils.validateState, source, value
+            @setState nextState

--- a/client/app/components/accounts/wizard/creation.cjsx
+++ b/client/app/components/accounts/wizard/creation.cjsx
@@ -10,7 +10,7 @@ Servers = require '../servers'
 
 RequestsStore = require '../../../stores/requests_store'
 
-RouterGetter = require '../../../getters/router'
+RequestsGetter = require '../../../getters/requests'
 
 AccountActionCreator = require '../../../actions/account_action_creator'
 RouterActionCreator = require '../../../actions/router_action_creator'
@@ -29,16 +29,16 @@ module.exports = AccountWizardCreation = React.createClass
     ]
 
 
-    # Build state from RequestsStore through RouterGetter
+    # Build state from RequestsStore through RequestsGetter
     getStateFromStores: ->
-        account  = RouterGetter.getAccountCreationSuccess()?.account
-        discover = RouterGetter.getAccountCreationDiscover()
+        account  = RequestsGetter.getAccountCreationSuccess()?.account
+        discover = RequestsGetter.getAccountCreationDiscover()
 
         state =
-            isBusy:         RouterGetter.getAccountCreationBusy()
-            isDiscoverable: RouterGetter.getAccountIsDiscoverable()
-            alert:          RouterGetter.getAccountCreationAlert()
-            OAuth:          RouterGetter.getAccountIsOAuth()
+            isBusy:         RequestsGetter.isAccountCreationBusy()
+            isDiscoverable: RequestsGetter.isAccountDiscoverable()
+            alert:          RequestsGetter.getAccountCreationAlert()
+            OAuth:          RequestsGetter.isAccountOAuth()
 
         state.success = _.partial @redirect, account if account
         _.extend state, @parseProviders discover if discover

--- a/client/app/components/application.coffee
+++ b/client/app/components/application.coffee
@@ -138,6 +138,7 @@ module.exports = React.createClass
 
             if @state.action is AccountActions.CREATE
                 AccountWizardCreation
+                    key: 'modal-account-wizard'
                     hasDefaultAccount: RouterGetter.getAccountID()?
 
             # Display feedback

--- a/client/app/getters/requests.coffee
+++ b/client/app/getters/requests.coffee
@@ -1,0 +1,74 @@
+{Requests
+RequestStatus} = require '../constants/app_constants'
+
+RequestsStore = require '../stores/requests_store'
+
+
+module.exports =
+    isAccountCreationBusy: ->
+        RequestStatus.INFLIGHT in [
+            RequestsStore.get(Requests.DISCOVER_ACCOUNT).status
+            RequestsStore.get(Requests.CHECK_ACCOUNT).status
+            RequestsStore.get(Requests.ADD_ACCOUNT).status
+        ]
+
+
+    isAccountDiscoverable: ->
+        discover = RequestsStore.get Requests.DISCOVER_ACCOUNT
+        check    = RequestsStore.get Requests.CHECK_ACCOUNT
+
+        if discover.status is RequestStatus.SUCCESS
+            return true
+        # autodiscover failed w/o check in course: switch to manual config
+        else if discover.status is RequestStatus.ERROR and check.status is null
+            return false
+        else
+            return check.status is null
+
+
+    getAccountCreationAlert: ->
+        discover = RequestsStore.get Requests.DISCOVER_ACCOUNT
+        check    = RequestsStore.get Requests.CHECK_ACCOUNT
+        create   = RequestsStore.get Requests.ADD_ACCOUNT
+
+        if create.status is RequestStatus.ERROR
+            'CREATE_FAILED'
+
+        else if check.status is RequestStatus.ERROR
+            'CHECK_FAILED'
+
+        # autodiscover failed: set an alert only if check isn't already
+        # performed
+        else if discover.status is RequestStatus.ERROR and check.status is null
+            'DISCOVER_FAILED'
+
+        else
+            null
+
+
+    isAccountOAuth: ->
+        check = RequestsStore.get Requests.CHECK_ACCOUNT
+
+        if check.status is RequestStatus.ERROR
+            check.res.oauth
+        else
+            false
+
+
+    getAccountCreationDiscover: ->
+        discover = RequestsStore.get Requests.DISCOVER_ACCOUNT
+
+        if discover.status is RequestStatus.SUCCESS
+            discover.res
+        else
+            false
+
+
+    getAccountCreationSuccess: ->
+        create = RequestsStore.get Requests.ADD_ACCOUNT
+
+        # return create request result (i.e. `{account}`) on success
+        if create.status is RequestStatus.SUCCESS
+            create.res
+        else
+            false

--- a/client/app/getters/router.coffee
+++ b/client/app/getters/router.coffee
@@ -2,7 +2,7 @@ AccountStore          = require '../stores/account_store'
 MessageStore          = require '../stores/message_store'
 NotificationStore     = require '../stores/notification_store'
 RefreshesStore        = require '../stores/refreshes_store'
-RequestsInFlightStore = require '../stores/requests_in_flight_store'
+RequestsStore = require '../stores/requests_store'
 RouterStore           = require '../stores/router_store'
 SearchStore           = require '../stores/search_store'
 
@@ -42,7 +42,7 @@ module.exports =
         RouterStore.getAction()
 
     getRequestStatus: (request) ->
-        RequestsInFlightStore.getRequests().get request
+        RequestsStore.getRequests().get request
 
     getReplyMessage: (messageID) ->
         isReply = @getAction() is MessageActions.EDIT

--- a/client/app/getters/router.coffee
+++ b/client/app/getters/router.coffee
@@ -1,7 +1,5 @@
 {MailboxFlags
-MessageActions
-Requests
-RequestStatus} = require '../constants/app_constants'
+MessageActions} = require '../constants/app_constants'
 
 _         = require 'lodash'
 Immutable = require 'immutable'
@@ -11,7 +9,6 @@ AccountStore      = require '../stores/account_store'
 MessageStore      = require '../stores/message_store'
 NotificationStore = require '../stores/notification_store'
 RefreshesStore    = require '../stores/refreshes_store'
-RequestsStore     = require '../stores/requests_store'
 RouterStore       = require '../stores/router_store'
 SearchStore       = require '../stores/search_store'
 
@@ -153,75 +150,6 @@ module.exports =
     getAccount: (accountID) ->
         accountID ?= @getAccountID()
         RouterStore.getAccount()
-
-
-    getAccountCreationBusy: ->
-        RequestStatus.INFLIGHT in [
-            RequestsStore.get(Requests.DISCOVER_ACCOUNT).status
-            RequestsStore.get(Requests.CHECK_ACCOUNT).status
-            RequestsStore.get(Requests.ADD_ACCOUNT).status
-        ]
-
-
-    getAccountIsDiscoverable: ->
-        discover = RequestsStore.get Requests.DISCOVER_ACCOUNT
-        check    = RequestsStore.get Requests.CHECK_ACCOUNT
-
-        if discover.status is RequestStatus.SUCCESS
-            return true
-        # autodiscover failed w/o check in course: switch to manual config
-        else if discover.status is RequestStatus.ERROR and check.status is null
-            return false
-        else
-            return check.status is null
-
-
-    getAccountCreationAlert: ->
-        discover = RequestsStore.get Requests.DISCOVER_ACCOUNT
-        check    = RequestsStore.get Requests.CHECK_ACCOUNT
-        create   = RequestsStore.get Requests.ADD_ACCOUNT
-
-        if create.status is RequestStatus.ERROR
-            'CREATE_FAILED'
-
-        else if check.status is RequestStatus.ERROR
-            'CHECK_FAILED'
-
-        # autodiscover failed: set an alert only if check isn't already
-        # performed
-        else if discover.status is RequestStatus.ERROR and check.status is null
-            'DISCOVER_FAILED'
-
-        else
-            null
-
-
-    getAccountIsOAuth: ->
-        check = RequestsStore.get Requests.CHECK_ACCOUNT
-
-        if check.status is RequestStatus.ERROR
-            check.res.oauth
-        else
-            false
-
-
-    getAccountCreationDiscover: ->
-        discover = RequestsStore.get Requests.DISCOVER_ACCOUNT
-
-        if discover.status is RequestStatus.SUCCESS
-            discover.res
-        else
-            false
-
-
-    getAccountCreationSuccess: ->
-        create = RequestsStore.get Requests.ADD_ACCOUNT
-
-        # return create request result (i.e. `{account}`) on success
-        if create.status is RequestStatus.SUCCESS
-            create.res
-        else
-            false
 
 
     getMailboxID: ->

--- a/client/app/libs/accounts.coffee
+++ b/client/app/libs/accounts.coffee
@@ -1,3 +1,14 @@
+###
+
+Accounts lib
+===
+
+This library is a simple set of helpers functions useful for parsing and
+validating account's related data (such as components states or requests
+responses).
+
+###
+
 {ServersEncProtocols} = require '../constants/app_constants'
 
 _ = require 'underscore'
@@ -8,7 +19,7 @@ module.exports =
     # Take a state identifier (key), its value, and the previousState.
     # It ensures the type is right with PropTypes, and manage auto-filling for
     # associated keys (logins / passwords).
-    validateAccountState: (key, value, pState) ->
+    validateState: (key, value, pState) ->
         # In case key is 'port', ensure the value type is a number
         value = +value if /port$/i.test key
 

--- a/client/app/stores/notification_store.coffee
+++ b/client/app/stores/notification_store.coffee
@@ -214,12 +214,12 @@ class NotificationStore extends Store
         #         key = "account creation ok configuration needed"
 
 
-        handle ActionTypes.EDIT_ACCOUNT_FAILURE, ({error}) ->
-            AppDispatcher.waitFor [AccountStore.dispatchToken]
-            _showNotification
-               message: RouterStore.getAlertErrorMessage()
-               errors: RouterStore.getRawErrors()
-               autoclose: true
+        # handle ActionTypes.EDIT_ACCOUNT_FAILURE, ({error}) ->
+        #     AppDispatcher.waitFor [AccountStore.dispatchToken]
+        #     _showNotification
+        #        message: RouterStore.getAlertErrorMessage()
+        #        errors: RouterStore.getRawErrors()
+        #        autoclose: true
 
         handle ActionTypes.EDIT_ACCOUNT_SUCCESS, ->
             _showNotification

--- a/client/app/stores/requests_store.coffee
+++ b/client/app/stores/requests_store.coffee
@@ -30,8 +30,8 @@ class RequestsStore extends Store
     _requests = _reset()
 
 
-    getRequests: ->
-        return _requests
+    get: (req) ->
+        return _requests.get req
 
 
     __bindHandlers: (handle) ->

--- a/client/app/stores/requests_store.coffee
+++ b/client/app/stores/requests_store.coffee
@@ -1,3 +1,16 @@
+###
+
+RequestsStore
+=============
+
+Handles current requests performed in background to let components aware of
+their current status.
+
+TODO: when migrating to a stateless server app, all requests status should be
+handled by realtime stack and this store should be deprecated.
+
+###
+
 Immutable = require 'immutable'
 
 Store = require '../libs/flux/store/store'
@@ -12,7 +25,7 @@ _reset = ->
         "#{Requests.ADD_ACCOUNT}":      status: null, res: undefined
 
 
-class RequestsInFlightStore extends Store
+class RequestsStore extends Store
 
     _requests = _reset()
 
@@ -83,4 +96,4 @@ class RequestsInFlightStore extends Store
             @emit 'change'
 
 
-module.exports = new RequestsInFlightStore()
+module.exports = new RequestsStore()

--- a/client/app/stores/router_store.coffee
+++ b/client/app/stores/router_store.coffee
@@ -44,9 +44,9 @@ class RouterStore extends Store
     _tab = null
 
     _refreshMailbox = false
-    _newAccountWaiting = false
-    _newAccountChecking = false
-    _serverAccountErrorByField = Immutable.Map()
+    # _newAccountWaiting = false
+    # _newAccountChecking = false
+    # _serverAccountErrorByField = Immutable.Map()
 
     _conversationID = null
     _messageID = null
@@ -71,28 +71,28 @@ class RouterStore extends Store
         _modal
 
 
-    getErrors: ->
-        _serverAccountErrorByField
+    # getErrors: ->
+    #     _serverAccountErrorByField
 
 
-    getRawErrors: ->
-        _serverAccountErrorByField.get 'unknown'
+    # getRawErrors: ->
+    #     _serverAccountErrorByField.get 'unknown'
 
 
-    getAlertErrorMessage: ->
-        error = _serverAccountErrorByField.first()
-        if error.name is 'AccountConfigError'
-            return t "config error #{error.field}"
-        else
-            return error.message or error.name or error
+    # getAlertErrorMessage: ->
+    #     error = _serverAccountErrorByField.first()
+    #     if error.name is 'AccountConfigError'
+    #         return t "config error #{error.field}"
+    #     else
+    #         return error.message or error.name or error
 
 
-    isWaiting: ->
-        _newAccountWaiting
+    # isWaiting: ->
+    #     _newAccountWaiting
 
 
-    isChecking: ->
-        _newAccountChecking
+    # isChecking: ->
+    #     _newAccountChecking
 
 
     isRefresh: ->
@@ -447,34 +447,34 @@ class RouterStore extends Store
         _URI
 
 
-    _clearError = ->
-        _serverAccountErrorByField = Immutable.Map()
+    # _clearError = ->
+    #     _serverAccountErrorByField = Immutable.Map()
 
 
-    _addError = (field, err) ->
-        _serverAccountErrorByField = _serverAccountErrorByField.set field, err
+    # _addError = (field, err) ->
+    #     _serverAccountErrorByField = _serverAccountErrorByField.set field, err
 
 
-    _checkForNoMailbox = (rawAccount) ->
-        unless rawAccount.mailboxes?.size > 0
-            _setError
-                name: 'AccountConfigError',
-                field: 'nomailboxes'
-                causeFields: ['nomailboxes']
+    # _checkForNoMailbox = (rawAccount) ->
+    #     unless rawAccount.mailboxes?.size > 0
+    #         _setError
+    #             name: 'AccountConfigError',
+    #             field: 'nomailboxes'
+    #             causeFields: ['nomailboxes']
 
 
-    _setError = (error) ->
-        if error.name is 'AccountConfigError'
-            clientError =
-                message: t "config error #{error.field}"
-                originalError: error.originalError
-                originalErrorStack: error.originalErrorStack
-            errorsMap = {}
-            errorsMap[field] = clientError for field in error.causeFields
-            _serverAccountErrorByField = Immutable.Map errorsMap
-
-        else
-            _serverAccountErrorByField = Immutable.Map "unknown": error
+    # _setError = (error) ->
+    #     if error.name is 'AccountConfigError'
+    #         clientError =
+    #             message: t "config error #{error.field}"
+    #             originalError: error.originalError
+    #             originalErrorStack: error.originalErrorStack
+    #         errorsMap = {}
+    #         errorsMap[field] = clientError for field in error.causeFields
+    #         _serverAccountErrorByField = Immutable.Map errorsMap
+    #
+    #     else
+    #         _serverAccountErrorByField = Immutable.Map "unknown": error
 
 
     _updateURL = ->
@@ -558,14 +558,14 @@ class RouterStore extends Store
             @emit 'change'
 
 
-        handle ActionTypes.ADD_ACCOUNT_REQUEST, ({value}) ->
-            _newAccountWaiting = true
-            @emit 'change'
+        # handle ActionTypes.ADD_ACCOUNT_REQUEST, ({value}) ->
+        #     _newAccountWaiting = true
+        #     @emit 'change'
 
 
         handle ActionTypes.ADD_ACCOUNT_SUCCESS, ({account}) ->
             _timerRouteChange = setTimeout =>
-                _newAccountWaiting = false
+                # _newAccountWaiting = false
                 _action            = MessageActions.SHOW_ALL
 
                 _setCurrentAccount account.id, account.inboxMailbox
@@ -575,44 +575,44 @@ class RouterStore extends Store
             , 5000
 
 
-        handle ActionTypes.ADD_ACCOUNT_FAILURE, ({error}) ->
-            _newAccountWaiting = false
-            _setError error
-            @emit 'change'
+        # handle ActionTypes.ADD_ACCOUNT_FAILURE, ({error}) ->
+        #     _newAccountWaiting = false
+        #     _setError error
+        #     @emit 'change'
 
 
-        handle ActionTypes.CHECK_ACCOUNT_REQUEST, () ->
-            _newAccountChecking = true
-            @emit 'change'
+        # handle ActionTypes.CHECK_ACCOUNT_REQUEST, () ->
+        #     _newAccountChecking = true
+        #     @emit 'change'
 
 
-        handle ActionTypes.CHECK_ACCOUNT_SUCCESS, () ->
-            _newAccountChecking = false
-            @emit 'change'
+        # handle ActionTypes.CHECK_ACCOUNT_SUCCESS, () ->
+        #     _newAccountChecking = false
+        #     @emit 'change'
 
 
-        handle ActionTypes.CHECK_ACCOUNT_FAILURE, ({error}) ->
-            _newAccountChecking = false
-            _setError error
-            @emit 'change'
+        # handle ActionTypes.CHECK_ACCOUNT_FAILURE, ({error}) ->
+        #     _newAccountChecking = false
+        #     _setError error
+        #     @emit 'change'
 
 
-        handle ActionTypes.EDIT_ACCOUNT_REQUEST, ({value}) ->
-            _newAccountWaiting = true
-            @emit 'change'
+        # handle ActionTypes.EDIT_ACCOUNT_REQUEST, ({value}) ->
+        #     _newAccountWaiting = true
+        #     @emit 'change'
 
 
-        handle ActionTypes.EDIT_ACCOUNT_SUCCESS, ({rawAccount}) ->
-            _newAccountWaiting = false
-            _checkForNoMailbox rawAccount
-            _clearError()
-            @emit 'change'
+        # handle ActionTypes.EDIT_ACCOUNT_SUCCESS, ({rawAccount}) ->
+        #     _newAccountWaiting = false
+        #     _checkForNoMailbox rawAccount
+        #     _clearError()
+        #     @emit 'change'
 
 
-        handle ActionTypes.EDIT_ACCOUNT_FAILURE, ({error}) ->
-            _newAccountWaiting = false
-            _setError error
-            @emit 'change'
+        # handle ActionTypes.EDIT_ACCOUNT_FAILURE, ({error}) ->
+        #     _newAccountWaiting = false
+        #     _setError error
+        #     @emit 'change'
 
 
         handle ActionTypes.MESSAGE_FETCH_REQUEST, ->

--- a/tests/client-units/account_store.coffee
+++ b/tests/client-units/account_store.coffee
@@ -21,8 +21,8 @@ describe 'AccountStore initialized without account', ->
     it 'Then the default account is still null', ->
         should.not.exist AccountStore.getDefault()
 
-    it 'Then AccountStore.isWaiting is true', ->
-        RouterStore.isWaiting().should.be.true
+    # it 'Then AccountStore.isWaiting is true', ->
+    #     RouterStore.isWaiting().should.be.true
 
     it 'When i receive a successful response (with no mailboxes)', ->
         dispatch ActionTypes.ADD_ACCOUNT_SUCCESS, account:
@@ -40,12 +40,12 @@ describe 'AccountStore initialized without account', ->
     it 'Then the created account should be selected', ->
         RouterStore.getAccountID().should.equal 'testid'
 
-    it 'Then AccountStore.isWaiting is false', ->
-        RouterStore.isWaiting().should.be.false
+    # it 'Then AccountStore.isWaiting is false', ->
+    #     RouterStore.isWaiting().should.be.false
 
-    it 'Then AccountStore should have a nomailboxes error', ->
-        noMailboxErr = RouterStore.getErrors().get('nomailboxes')
-        noMailboxErr.message.should.equal 'translated config error nomailboxes'
+    # it 'Then AccountStore should have a nomailboxes error', ->
+    #     noMailboxErr = RouterStore.getErrors().get('nomailboxes')
+    #     noMailboxErr.message.should.equal 'translated config error nomailboxes'
 
     it 'When i send a request to create a second account', ->
         dispatch ActionTypes.ADD_ACCOUNT_REQUEST, {}
@@ -53,8 +53,8 @@ describe 'AccountStore initialized without account', ->
     it 'Then the default account is the previously created', ->
         AccountStore.getDefault().get('id').should.equal 'testid'
 
-    it 'Then AccountStore.isWaiting is true', ->
-        RouterStore.isWaiting().should.be.true
+    # it 'Then AccountStore.isWaiting is true', ->
+    #     RouterStore.isWaiting().should.be.true
 
     it 'When i receive an error response', ->
         dispatch ActionTypes.ADD_ACCOUNT_FAILURE, error:
@@ -65,15 +65,15 @@ describe 'AccountStore initialized without account', ->
     it 'Then the default account is still the same', ->
         AccountStore.getDefault().get('id').should.equal 'testid'
 
-    it 'Then RouterStore.isWaiting is false', ->
-        RouterStore.isWaiting().should.be.false
+    # it 'Then RouterStore.isWaiting is false', ->
+    #     RouterStore.isWaiting().should.be.false
 
-    it 'Then RouterStore should have some errors', ->
-        should.exist RouterStore.getErrors().get('smtp')
-        error = RouterStore.getErrors().get('smtp')
-        error.message.should.equal 'translated config error smtp'
-        error.should.equal RouterStore.getErrors().get('smtpLogin')
-        error.should.equal RouterStore.getErrors().get('smtpPort')
+    # it 'Then RouterStore should have some errors', ->
+    #     should.exist RouterStore.getErrors().get('smtp')
+    #     error = RouterStore.getErrors().get('smtp')
+    #     error.message.should.equal 'translated config error smtp'
+    #     error.should.equal RouterStore.getErrors().get('smtpLogin')
+    #     error.should.equal RouterStore.getErrors().get('smtpPort')
 
 TEST_ACCOUNT =
     id: 'testid'


### PR DESCRIPTION
This PR is in continuity of #839, base on the code review from @misstick. It introduces:
- move state logics into getters
- rename the so-badly-named `RequestsInFlightStore`
- disable legacy code for requests states and errors

Concerning this last, I keep code commented at this time as long as a dedicated PR for dead-code removing will become soon.

@misstick, I have some points that I won't address:
- The StoreWatchMixin in the _Creation_ component: I assume a modal isn't directly relied to the application and won't inherit of all its states. Plus, I listen the _RequestsStore_ rather than the RouterStore as long all its events loops comes from background requests only. I assume we improve this when we'll implement the real URL to modal (in query params) logic, as discussed
- There's always a mixin for code sharing between the _Creation_ component, the upcoming _Settings/Edit_ component and some _action creators_. If you prefer to keep it isolated in another way (a lib? a getter (but it only _parse_ and never _get_ data)?), let me know
- I haven't implemented the query param routing for modals, I prefer to keep it in a dedicated PR (and it isn't an uncontrollable urge)

**EDIT**: as discussed in review, about architecture questions:
- Using a `StoreWatchMixin` is OK for top-level components only (aka: the application's main view, and the various modals), at the condition they use a proper `key` on component that is uniq for same behaviors (settings, account-creation, draft, etc)
- Mixin should be avoid, except if what we want is an inherited behavior accross various components. Here, it's more a lib, that provides helper methods to parse and validate data. _About libs_: libs and utils are probably the same things, in that they provides a set of useful helpers, but a lib is more high-level code, when utils are just a collection of unrelated method about a same theme. To avoid unwanted complexity, say that every sets of helpers are a lib :smile:.
- Modal are handled by a query param (not active here, but will be enabled in a dedicated PR about routing)