### PR TITLE
Fix gateway timeouts

### DIFF
--- a/client/app/components/menu.coffee
+++ b/client/app/components/menu.coffee
@@ -53,7 +53,6 @@ module.exports = Menu = React.createClass
                                 div
                                     className: 'account-details',
                                         span {}, @props?.search
-
                 @props.accounts.map @renderMailBoxes
 
             nav className: 'submenu',
@@ -138,7 +137,7 @@ module.exports = Menu = React.createClass
                     className: 'list-unstyled mailbox-list',
 
                     # Default Inbox Mailboxes
-                    props.inboxMailboxes?.map (mailbox, key) =>
+                    props.inboxMailboxes?.valueSeq().map (mailbox, key) =>
                         mailboxURL = RouterGetter.getURL
                             mailboxID: (mailboxID = mailbox.get 'id')
                             resetFilter: true
@@ -182,7 +181,7 @@ module.exports = Menu = React.createClass
                         mailboxID:          account.get 'inboxMailbox'
 
                     # Other mailboxes
-                    props.otherMailboxes?.map (mailbox, key) =>
+                    props.otherMailboxes?.valueSeq().map (mailbox, key) =>
                         mailboxURL = RouterGetter.getURL
                             mailboxID: (mailboxID = mailbox.get 'id')
                             resetFilter: true

--- a/client/package.json
+++ b/client/package.json
@@ -16,7 +16,8 @@
     "react-dom": "0.14.7",
     "react-onclickoutside": "4.5.0",
     "socket.io-client": "1.4.5",
-    "superagent": "1.7.2",
+    "superagent": "2.0.0",
+    "superagent-throttle": "0.0.9",
     "to-markdown": "2.0.1",
     "underscore": "1.8.3"
   },


### PR DESCRIPTION
This PR tries to fix gateway timeouts by throttling huge / heavy requests.

*Context*: sometimes, the server node process is struggled by a too high number of requests (especially w/ Node < 4). This may result to _Gateway Timeouts_ requests as long as the server is still idle w/ previous concurrent requests. So we add a throttle (a plugin for superagent) that will delay requests from client to the server part to minimize the load and keep server below the struggle point. It applies on all `GET` requests, and on some heavy `PUT`/`POST` requests (like batch updates) that may overload the server.