### PR TITLE
Preserve counter badges space

### DIFF
--- a/client/app/components/menu_mailbox_item.coffee
+++ b/client/app/components/menu_mailbox_item.coffee
@@ -63,6 +63,6 @@ module.exports = React.createClass
                     span className: 'refresh-error', onClick: displayError,
                         i className: 'fa fa-warning', null
 
-
-            if not @props.isMailboxLoading and @props.unread
-                span className: 'badge', @props.unread
+            div className: 'badges',
+                if not @props.isMailboxLoading and @props.unread
+                    span className: 'badge', @props.unread

--- a/client/app/styles/_menu.styl
+++ b/client/app/styles/_menu.styl
@@ -85,6 +85,13 @@ subaction()
         position    relative
         align-items center
 
+
+    .badges
+        flex         1 0 auto
+        min-width    3em
+        padding-right 0.625em
+        text-align   right
+
     .badge
         order       2
         margin-left auto
@@ -140,9 +147,6 @@ subaction()
         .account
             flex 1
 
-        .badge
-            margin-right 1em
-
 
     .menu-subaction
         color #aaa
@@ -163,7 +167,6 @@ subaction()
 
         li
             display       flex
-            padding-left 0.875em
             border-radius .25rem
 
             &.active
@@ -179,15 +182,12 @@ subaction()
                         font-size 0.875em
 
             a
-                flex 1
+                flex 6 1 auto    // regarding from badges section at flex: 1
 
                 .fa
                     // horizontally centered icons
                     width      1em
                     text-align center
-
-            .badge
-                margin-right .5em
 
             &:hover
                 a


### PR DESCRIPTION
This PR wrap badges counters in a `.badges` block to ensure space in flexbox layout is preserved at load, when counter aren't already available. It fixes to flickering effect that occurs ahen menu load and display before counters are available.