### PR TITLE
Prevent application to crash when there is no account

### DIFF
--- a/client/app/stores/router_store.coffee
+++ b/client/app/stores/router_store.coffee
@@ -504,8 +504,8 @@ class RouterStore extends Store
             # without accounts
             _setCurrentAction payload
 
-            mailboxID ?= AccountStore.getDefault().get 'inboxMailbox'
-            accountID ?= AccountStore.getByMailbox(mailboxID).get 'id'
+            mailboxID ?= AccountStore.getDefault()?.get 'inboxMailbox'
+            accountID ?= AccountStore.getByMailbox(mailboxID)?.get 'id'
             _setCurrentAccount {accountID, mailboxID, tab}
 
             # From MessageStore


### PR DESCRIPTION
On my first launch, Emails crashed with an error related to undefined account. This PR fixes this issue.

I still have unit tests to write (I am currently looking at existing tests)

@misstick please review, or assign someone else. :)

