### PR TITLE
Migrate LayoutStore to LayoutReducer base on redux.

### DIFF
--- a/client/app/getters/layout.coffee
+++ b/client/app/getters/layout.coffee
@@ -1,19 +1,19 @@
 
-LayoutStore = require '../stores/layout_store'
+reduxStore = require '../reducers/_store'
 
 module.exports =
 
 
     getPreviewSize: ->
-        LayoutStore.getPreviewSize()
+        reduxStore.getState().layout.previewSize
 
 
     isIntentAvailable: ->
-        LayoutStore.isIntentAvailable()
+        reduxStore.getState().layout.intentAvailable
 
 
     isToastHidden: ->
-        LayoutStore.isToastHidden()
+        reduxStore.getState().layout.hidden
 
 
     # Check if an element is inside visible viewport

--- a/client/app/reducers/layout.coffee
+++ b/client/app/reducers/layout.coffee
@@ -1,0 +1,30 @@
+Immutable = require 'immutable'
+
+{ActionTypes} = require '../constants/app_constants'
+
+DEFAULT_STATE =
+    # Should definetly be in view or settings file.
+    previewSize: 60
+    hidden: true
+    intentAvailable: false
+
+module.exports = (state=DEFAULT_STATE, action) ->
+
+    switch action.type
+        # TOASTS_SHOW
+        when ActionTypes.TOASTS_SHOW
+            nextstate = Object.assign state, hidden: false
+
+
+        # TOASTS_HIDE
+        when ActionTypes.TOASTS_HIDE
+            nextState = Object.assign state, hidden: true
+
+
+        # INTENT_AVAILABLE
+        when ActionTypes.INTENT_AVAILABLE
+            availability = action.value
+            nextstate = Object.assign state, intentAvailable: availability
+
+
+    return nextstate or state

--- a/client/app/reducers/root.coffee
+++ b/client/app/reducers/root.coffee
@@ -1,10 +1,12 @@
 
 selectionReducer = require './selection'
 messagesReducer = require './message'
+layoutReducer = require './layout'
 {combineReducers} = require('redux')
 
 
 module.exports = combineReducers({
     selection: selectionReducer
     messages: messagesReducer
+    layout: layoutReducer
 })

--- a/client/test/layout_store.spec.js
+++ b/client/test/layout_store.spec.js
@@ -1,41 +1,74 @@
 'use strict';
 const assert = require('chai').assert;
 
-const mockeryUtils = require('./utils/mockery_utils');
-const SpecDispatcher = require('./utils/specs_dispatcher');
 const ActionTypes = require('../app/constants/app_constants').ActionTypes;
+const layoutReducer = require('../app/reducers/layout');
 
-
-describe('Layout Store', () => {
-  let layoutStore;
-  let dispatcher;
-
-  before(() => {
-    dispatcher = new SpecDispatcher();
-    mockeryUtils.initDispatcher(dispatcher);
-    mockeryUtils.initForStores(['../app/stores/layout_store']);
-    layoutStore = require('../app/stores/layout_store');
-  });
-
+describe('Layout Reducer', () => {
   describe('Actions', () => {
-    it.skip('TOASTS_SHOW', () => {
-      dispatcher.dispatch({ type: ActionTypes.TOASTS_SHOW });
-      assert.equal(layoutStore.isToastHidden(), false);
-    });
-    it.skip('TOASTS_HIDE', () => {
-      dispatcher.dispatch({ type: ActionTypes.TOASTS_HIDE });
-      assert.equal(layoutStore.isToastHidden(), true);
-    });
-    it.skip('INTENT_AVAILABLE', () => {
-      dispatcher.dispatch({
-        type: ActionTypes.INTENT_AVAILABLE,
-        value: true,
-      });
-      assert.equal(layoutStore.isIntentAvailable(), true);
-    });
-  });
 
-  after(() => {
-    mockeryUtils.clean();
+    describe('TOASTS_SHOW', () => {
+      it('should set hidden to false', () => {
+        // arrange
+        let state = null;
+        let action = {
+          type: ActionTypes.TOASTS_SHOW
+        };
+
+        // act
+        let result = layoutReducer(state, action);
+
+        // assert
+        assert.isFalse(result.hidden);
+      });
+    });
+
+    describe('TOASTS_HIDE', () => {
+      it('should set hidden to true', () => {
+        // arrange
+        let state = null;
+        let action = {
+          type: ActionTypes.TOASTS_HIDE
+        };
+
+        // act
+        let result = layoutReducer(state, action);
+
+        // assert
+        assert.isTrue(result.hidden);
+      });
+    });
+
+    describe('INTENT_AVAILABLE', () => {
+      it('should set intentAvailable to true', () => {
+        // arrange
+        let state = null;
+        let action = {
+          type: ActionTypes.INTENT_AVAILABLE,
+          value: true,
+        };
+
+        // act
+        let result = layoutReducer(state, action);
+
+        // assert
+        assert.isTrue(result.intentAvailable);
+      });
+
+      it('should set intentAvailable to false', () => {
+        // arrange
+        let state = null;
+        let action = {
+          type: ActionTypes.INTENT_AVAILABLE,
+          value: false,
+        };
+
+        // act
+        let result = layoutReducer(state, action);
+
+        // assert
+        assert.isFalse(result.intentAvailable);
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR is ready to merge, please @anaerio have a review. :)

I kept the `contact_store.spec.js` name as requested, but as you will see almost
the whole file has changed.