### PR TITLE
Migrate Settings Store to redux

### DIFF
--- a/client/app/getters/settings.coffee
+++ b/client/app/getters/settings.coffee
@@ -1,0 +1,8 @@
+
+reduxStore = require '../reducers/_store'
+pure = require '../puregetters/settings'
+
+module.exports =
+
+    get: (settingName = null) ->
+        pure.get reduxStore.getState(), settingName

--- a/client/app/puregetters/settings.coffee
+++ b/client/app/puregetters/settings.coffee
@@ -1,0 +1,6 @@
+
+module.exports =
+    get: (state, settingName) ->
+        settings = state.settings.settings
+        return settings.toObject() unless settingName
+        return settings.get settingName

--- a/client/app/puregetters/settings.coffee
+++ b/client/app/puregetters/settings.coffee
@@ -1,6 +1,6 @@
 
 module.exports =
     get: (state, settingName) ->
-        settings = state.settings.settings
+        settings = state.settings
         return settings.toObject() unless settingName
         return settings.get settingName

--- a/client/app/reducers/_store.coffee
+++ b/client/app/reducers/_store.coffee
@@ -1,8 +1,11 @@
+Immutable = require 'immutable'
 {createStore} = require 'redux'
 rootReducer = require './root'
 dispatcher = require '../libs/flux/dispatcher/dispatcher'
 
-reduxStore = createStore(rootReducer, {})
+reduxStore = createStore rootReducer,
+    settings:
+        settings: Immutable.Map window?.settings
 
 reduxStoreDispatchID = dispatcher.register (action) ->
     reduxStore.dispatch(action)

--- a/client/app/reducers/root.coffee
+++ b/client/app/reducers/root.coffee
@@ -1,10 +1,12 @@
 
 selectionReducer = require './selection'
 messagesReducer = require './message'
+settingsReducer = require './settings'
 {combineReducers} = require('redux')
 
 
 module.exports = combineReducers({
     selection: selectionReducer
     messages: messagesReducer
+    settings: settingsReducer
 })

--- a/client/app/reducers/settings.coffee
+++ b/client/app/reducers/settings.coffee
@@ -2,14 +2,13 @@ Immutable = require 'immutable'
 
 {ActionTypes} = require '../constants/app_constants'
 
-DEFAULTSTATE =
-    settings: Immutable.Map()
+DEFAULTSTATE = Immutable.Map()
 
 module.exports = (state = DEFAULTSTATE, action) ->
 
     switch action.type
         when ActionTypes.SETTINGS_UPDATE_SUCCESS
             nextState =
-                settings: state.settings.merge action.value
+                settings: state.merge action.value
 
     return nextState or state

--- a/client/app/reducers/settings.coffee
+++ b/client/app/reducers/settings.coffee
@@ -1,0 +1,15 @@
+Immutable = require 'immutable'
+
+{ActionTypes} = require '../constants/app_constants'
+
+DEFAULTSTATE =
+    settings: Immutable.Map()
+
+module.exports = (state = DEFAULTSTATE, action) ->
+
+    switch action.type
+        when ActionTypes.SETTINGS_UPDATE_SUCCESS
+            nextState =
+                settings: state.settings.merge action.value
+
+    return nextState or state

--- a/client/test/settings_puregetter.spec.js
+++ b/client/test/settings_puregetter.spec.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const assert = require('chai').assert;
+const Immutable = require('immutable');
+
+const settingsPureGetter = require('../app/puregetters/settings');
+
+describe('Settings pure getter', () => {
+  describe('Methods', () => {
+
+    describe('get', () => {
+
+      it('should return all settings when no param', () => {
+        // arrange
+        let expectedSettings = {
+          setting1: 'value1',
+          setting2: 'value2',
+          setting3: 'value3',
+        };
+
+        let state = {
+          settings: {
+            settings: Immutable.Map(expectedSettings)
+          }
+        }
+
+        // act
+        let result = settingsPureGetter.get(state);
+
+        // assert
+        assert.deepEqual(result, expectedSettings);
+
+      });
+
+      it('should return given setting', () => {
+        // arrage
+        let expectedValue = 'value2';
+        let settings = {
+          setting1: 'value1',
+          setting2: 'value2',
+          setting3: 'value3'
+        };
+
+        let state = {
+          settings: {
+            settings: Immutable.Map(settings)
+          }
+        };
+
+        // act
+        let result = settingsPureGetter.get(state, 'setting2');
+
+        // assert
+        assert.equal(result, expectedValue);
+
+      });
+
+    });
+
+  });
+});

--- a/client/test/settings_puregetter.spec.js
+++ b/client/test/settings_puregetter.spec.js
@@ -19,9 +19,7 @@ describe('Settings pure getter', () => {
         };
 
         let state = {
-          settings: {
-            settings: Immutable.Map(expectedSettings)
-          }
+          settings: Immutable.Map(expectedSettings)
         }
 
         // act
@@ -42,9 +40,7 @@ describe('Settings pure getter', () => {
         };
 
         let state = {
-          settings: {
-            settings: Immutable.Map(settings)
-          }
+          settings: Immutable.Map(settings)
         };
 
         // act

--- a/client/test/settings_reducer.spec.js
+++ b/client/test/settings_reducer.spec.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const assert = require('chai').assert;
+const Immutable = require('immutable');
+
+const settingsReducer = require('../app/reducers/settings');
+
+describe('Settings Reducer', () => {
+  describe('Actions', () => {
+    describe('SETTINGS_UPDATE_SUCCESS', () => {
+
+      it('should initiate state\’s settings',  () => {
+        // arrange
+        let state = null
+        let action = {
+          type: 'SETTINGS_UPDATE_SUCCESS',
+          value: {
+            setting1: 'value1',
+            setting2:  'value2'
+          }
+        };
+
+        // act
+        let result = settingsReducer(state, action);
+
+        // assert
+        assert.isNotNull(result.settings);
+        assert.equal(result.settings.size, 2);
+        assert.equal('value1', result.settings.get('setting1'));
+        assert.equal('value2', result.settings.get('setting2'));
+      });
+
+      it('should merge state with new values', () => {
+        // arrange
+        let state = {
+          settings: Immutable.Map({
+            setting1: 'value1',
+            setting2: 'value2'
+          })
+        };
+
+        let action = {
+          type: 'SETTINGS_UPDATE_SUCCESS',
+          value: {
+            setting2: 'newValue2',
+            setting3: 'value3'
+          }
+        };
+
+        // act
+        let result = settingsReducer(state, action);
+
+        // assert
+        assert.equal(result.settings.size, 3);
+        assert.equal('value1', result.settings.get('setting1'));
+        assert.equal('newValue2', result.settings.get('setting2'));
+        assert.equal('value3', result.settings.get('setting3'));
+      });
+
+    });
+  });
+});

--- a/client/test/settings_reducer.spec.js
+++ b/client/test/settings_reducer.spec.js
@@ -32,12 +32,10 @@ describe('Settings Reducer', () => {
 
       it('should merge state with new values', () => {
         // arrange
-        let state = {
-          settings: Immutable.Map({
-            setting1: 'value1',
-            setting2: 'value2'
-          })
-        };
+        let state = Immutable.Map({
+          setting1: 'value1',
+          setting2: 'value2'
+        });
 
         let action = {
           type: 'SETTINGS_UPDATE_SUCCESS',


### PR DESCRIPTION
Thanks @anaerio to review this PR.

As we discussed, I created a pure getter for Settings.

I hesitated on the way to build the settings State, between using a single Map for the whole state or using a property.

```coffeescript
DEFAULT_STATE = Immutable.Map()
#or
DEFAULT_STATE =
  settings: Immutable.Map()
```

I kept the second solution to be consistent with the other migrations, but it forces us to call :

```coffeescript
reduxStore.getState().settings.settings
```