### PR TITLE
Fix invisible message issue on Firefox.

### DIFF
--- a/client/app/components/frame.coffee
+++ b/client/app/components/frame.coffee
@@ -3,9 +3,6 @@ ReactDOM  = require 'react-dom'
 
 {iframe, div} = React.DOM
 
-_counter = -1
-_loadMax = 10
-
 module.exports =  Frame = React.createClass
     displayName: 'Frame'
 
@@ -29,18 +26,41 @@ module.exports =  Frame = React.createClass
         doc
 
 
+    onDocumentReady: (doc) ->
+        ReactDOM.render @props.children, doc.body
+
+        # Resize Iframe content
+        # with ist content size
+        el = ReactDOM.findDOMNode(@)
+        el.setAttribute 'width', doc.body.scrollWidth
+        el.setAttribute 'height', doc.body.scrollHeight
+
+
     renderFrameContents: ->
-        if (doc = @getDocument())?.readyState is 'complete'
-            ReactDOM.render @props.children, doc.body
+        doc = @getDocument()
+        # TODO: Throw an error ?
+        return unless doc
 
-            # Resize Iframe content
-            # with ist content size
-            el = ReactDOM.findDOMNode(@)
-            el.setAttribute 'width', doc.body.scrollWidth
-            el.setAttribute 'height', doc.body.scrollHeight
+        # 'interactive' readyState seems to be also working, but as the previous
+        # code was testing only 'complete', there is for sure a good reason.
+        # So, there is still a little delay before displaying the message on
+        # Firefox, but it could be fastened by displaying as soon as the
+        # readyState is 'interactive'.
+        if doc.readyState is 'complete'
+            @onDocumentReady(doc)
+        else
+            # If ready state is not complete we wait for it by adding an event
+            # listener on 'readyStateChange' event.
 
-        else if _loadMax < ++_counter
-            setTimeout @renderFrameContents, 0
+            # Reference the readyStateChange handler to be able to remove it
+            # afterward.
+            readyStateChangeHandler = () =>
+                if doc.readyState is 'complete'
+                    @onDocumentReady(doc)
+                    doc.removeEventListener 'readystatechange',
+                        readyStateChangeHandler
+
+            doc.addEventListener 'readystatechange', readyStateChangeHandler
 
 
     componentDidUpdate: ->


### PR DESCRIPTION
Thanks @aenario to review this PR :)

The issue was due to a difference in readyState propert between Firefox and Chrome, as in Chrome readyState seems to be always complete, there was a little delay in Firefox. So this should be handled by an event listener on readySate change, but it was by a sort of "retry 10 times" called with a setTimeOut. As in Firefox the readyState was still not 'complete' after 10 retries, the message was never displayed correctly.

In general case, setTimeOut should never be used to deal with DOM changes.

NB: Rendering also when readyState is equal to `interactive` seems to fasten the rendering in Firefox, I don't know if there is any reason to only rely on `complete`.